### PR TITLE
Fix wrong typing on client.rest.guilds.get

### DIFF
--- a/lib/routes/Guilds.ts
+++ b/lib/routes/Guilds.ts
@@ -961,7 +961,7 @@ export default class Guilds {
      * @param id The ID of the guild.
      * @param withCounts If the approximate number of members and online members should be included.
      */
-    async get(id: string, withCounts?: number): Promise<Guild> {
+    async get(id: string, withCounts?: boolean): Promise<Guild> {
         const query = new URLSearchParams();
         if (withCounts) {
             query.set("with_counts", withCounts.toString());


### PR DESCRIPTION
i think its supposed to be [boolean](https://discord.com/developers/docs/resources/guild#get-guild-query-string-params)