### PR TITLE
fix: fix fetching max concurrency automatically

### DIFF
--- a/lib/Client.ts
+++ b/lib/Client.ts
@@ -171,7 +171,7 @@ export default class Client extends TypedEmitter<ClientEvents> {
             if (!data) {
                 throw new Error("AutoConcurrency failed, missing required information from Discord.");
             }
-            this.shards.options.concurrency = data.maxConcurrency ?? 1;
+            this.shards.options.concurrency = data.sessionStartLimit.maxConcurrency ?? 1;
         }
 
 

--- a/lib/Client.ts
+++ b/lib/Client.ts
@@ -171,7 +171,7 @@ export default class Client extends TypedEmitter<ClientEvents> {
             if (!data) {
                 throw new Error("AutoConcurrency failed, missing required information from Discord.");
             }
-            this.shards.options.concurrency = data.sessionStartLimit.maxConcurrency ?? 1;
+            this.shards.options.concurrency = data.sessionStartLimit.maxConcurrency;
         }
 
 

--- a/lib/rest/RESTManager.ts
+++ b/lib/rest/RESTManager.ts
@@ -60,7 +60,6 @@ export default class RESTManager {
             path:   Routes.GATEWAY_BOT
         }).then(data => ({
             url:               data.url,
-            maxConcurrency:    data.max_concurrency,
             shards:            data.shards,
             sessionStartLimit: {
                 total:          data.session_start_limit.total,

--- a/lib/types/gateway.d.ts
+++ b/lib/types/gateway.d.ts
@@ -147,7 +147,6 @@ export interface SessionStartLimit {
 
 
 export interface GetBotGatewayResponse extends GetGatewayResponse {
-    maxConcurrency?: number;
     sessionStartLimit: SessionStartLimit;
     shards: number;
 }

--- a/lib/types/gateway.d.ts
+++ b/lib/types/gateway.d.ts
@@ -126,7 +126,6 @@ export interface GetGatewayResponse {
 }
 
 export interface RawGetBotGatewayResponse extends GetGatewayResponse {
-    max_concurrency?: number;
     session_start_limit: RawSessionStartLimit;
     shards: number;
 }


### PR DESCRIPTION
Figured this out wondering why shards were slow *with* concurrency, seems like data.maxConcurrency is always `undefined` so dunno whether to set that from sessionStartLimit in the function or just remove it outright.