### PR TITLE
Fix avatar URLs for guild/member avatars

### DIFF
--- a/lib/structures/Member.ts
+++ b/lib/structures/Member.ts
@@ -5,6 +5,7 @@ import type Guild from "./Guild";
 import type Permission from "./Permission";
 import type VoiceState from "./VoiceState";
 import type { ImageFormat } from "../Constants";
+import * as Routes from "../util/Routes";
 import type Client from "../Client";
 import type {
     CreateBanOptions,
@@ -179,7 +180,7 @@ export default class Member extends Base {
      * @param size The dimensions of the image.
      */
     avatarURL(format?: ImageFormat, size?: number): string {
-        return this.avatar === null ? this.user.avatarURL(format, size) : this.client.util.formatImage(this.avatar, format, size);
+        return this.avatar === null ? this.user.avatarURL(format, size) : this.client.util.formatImage(Routes.GUILD_AVATAR(this.guildID, this.id, this.avatar), format, size);
     }
 
     /**


### PR DESCRIPTION
As of right now, when trying to use `avatarURL()` on a Member object with a non-null avatar, it returns a malformed URL like this:
```
https://cdn.discordapp.coma_ff23ddf64e0930ac1ac67f7ab6eeb84e.png?size=4096
```
Note the lack of a slash or path between the `.com` and the `a_`. This should fix it to return the proper guild avatar URL.