### PR TITLE
Fix #channel on many structures not properly getting cached channels

### DIFF
--- a/lib/structures/AutocompleteInteraction.ts
+++ b/lib/structures/AutocompleteInteraction.ts
@@ -58,7 +58,7 @@ export default class AutocompleteInteraction<T extends AnyTextChannelWithoutGrou
 
     /** The channel this interaction was sent from. */
     get channel(): T extends AnyTextChannelWithoutGroup ? T : undefined {
-        return this._cachedChannel ?? (this._cachedChannel = this.client.getChannel(this.channelID) as T extends AnyTextChannelWithoutGroup ? T : undefined);
+        return this._cachedChannel ??= this.client.getChannel(this.channelID) as T extends AnyTextChannelWithoutGroup ? T : undefined;
     }
 
     /** The guild this interaction was sent from, if applicable. This will throw an error if the guild is not cached. */

--- a/lib/structures/CommandInteraction.ts
+++ b/lib/structures/CommandInteraction.ts
@@ -134,7 +134,7 @@ export default class CommandInteraction<T extends AnyTextChannelWithoutGroup | U
 
     /** The channel this interaction was sent from. */
     get channel(): T extends AnyTextChannelWithoutGroup ? T : undefined {
-        return this._cachedChannel ?? (this._cachedChannel = this.client.getChannel(this.channelID) as T extends AnyTextChannelWithoutGroup ? T : undefined);
+        return this._cachedChannel ??= this.client.getChannel(this.channelID) as T extends AnyTextChannelWithoutGroup ? T : undefined;
     }
 
     /** The guild this interaction was sent from, if applicable. This will throw an error if the guild is not cached. */

--- a/lib/structures/ComponentInteraction.ts
+++ b/lib/structures/ComponentInteraction.ts
@@ -125,7 +125,7 @@ export default class ComponentInteraction<V extends ComponentTypes.BUTTON | Sele
 
     /** The channel this interaction was sent from. */
     get channel(): T extends AnyTextChannelWithoutGroup ? T : undefined {
-        return this._cachedChannel ?? (this._cachedChannel = this.client.getChannel(this.channelID) as T extends AnyTextChannelWithoutGroup ? T : undefined);
+        return this._cachedChannel ??= this.client.getChannel(this.channelID) as T extends AnyTextChannelWithoutGroup ? T : undefined;
     }
 
     /** The guild this interaction was sent from, if applicable. This will throw an error if the guild is not cached. */

--- a/lib/structures/GuildScheduledEvent.ts
+++ b/lib/structures/GuildScheduledEvent.ts
@@ -102,8 +102,8 @@ export default class GuildScheduledEvent extends Base {
 
     /** The channel in which the event will be hosted. `null` if entityType is `EXTERNAL` */
     get channel(): StageChannel | null | undefined {
-        if (this.channelID !== null && this._cachedChannel !== null) {
-            return this._cachedChannel ?? (this._cachedChannel = this.client.getChannel<StageChannel>(this.channelID));
+        if (this.channelID !== null) {
+            return this._cachedChannel ??= this.client.getChannel<StageChannel>(this.channelID);
         }
 
         return this._cachedChannel === null ? this._cachedChannel : (this._cachedChannel = null);

--- a/lib/structures/Invite.ts
+++ b/lib/structures/Invite.ts
@@ -145,7 +145,13 @@ export default class Invite<T extends InviteInfoTypes = "withMetadata", CH exten
     /** The channel this invite leads to. If the channel is not cached, this will be a partial with only `id`, `name, and `type`. */
     get channel(): (CH extends InviteChannel ? CH : PartialInviteChannel) | null {
         if (this.channelID !== null) {
-            return this._cachedChannel ??= this.client.getChannel<InviteChannel>(this.channelID) as CH extends InviteChannel ? CH : PartialInviteChannel;
+            if (this._cachedChannel instanceof Channel) {
+                return this._cachedChannel;
+            }
+
+            const cachedChannel = this.client.getChannel<InviteChannel>(this.channelID);
+
+            return cachedChannel ? (this._cachedChannel = cachedChannel as CH extends InviteChannel ? CH : PartialInviteChannel) : this._cachedChannel;
         }
 
         return this._cachedChannel === null ? this._cachedChannel : (this._cachedChannel = null);

--- a/lib/structures/Invite.ts
+++ b/lib/structures/Invite.ts
@@ -144,14 +144,8 @@ export default class Invite<T extends InviteInfoTypes = "withMetadata", CH exten
 
     /** The channel this invite leads to. If the channel is not cached, this will be a partial with only `id`, `name, and `type`. */
     get channel(): (CH extends InviteChannel ? CH : PartialInviteChannel) | null {
-        if (this.channelID !== null && this._cachedChannel !== null) {
-            if (this._cachedChannel instanceof Channel) {
-                return this._cachedChannel;
-            }
-
-            const cachedChannel = this.client.getChannel<InviteChannel>(this.channelID);
-
-            return (cachedChannel ? (this._cachedChannel = cachedChannel as CH extends InviteChannel ? CH : PartialInviteChannel) : this._cachedChannel);
+        if (this.channelID !== null) {
+            return this._cachedChannel ??= this.client.getChannel<InviteChannel>(this.channelID) as CH extends InviteChannel ? CH : PartialInviteChannel;
         }
 
         return this._cachedChannel === null ? this._cachedChannel : (this._cachedChannel = null);

--- a/lib/structures/Message.ts
+++ b/lib/structures/Message.ts
@@ -276,7 +276,7 @@ export default class Message<T extends AnyTextChannelWithoutGroup | Uncached = A
 
     /** The channel this message was created in. */
     get channel(): T extends AnyTextChannelWithoutGroup ? T : undefined {
-        return this._cachedChannel ?? (this._cachedChannel = this.client.getChannel(this.channelID) as T extends AnyTextChannelWithoutGroup ? T : undefined);
+        return this._cachedChannel ??= this.client.getChannel(this.channelID) as T extends AnyTextChannelWithoutGroup ? T : undefined;
     }
 
     /** The guild this message is in. This will throw an error if the guild is not cached. */

--- a/lib/structures/ModalSubmitInteraction.ts
+++ b/lib/structures/ModalSubmitInteraction.ts
@@ -55,7 +55,7 @@ export default class ModalSubmitInteraction<T extends AnyTextChannelWithoutGroup
 
     /** The channel this interaction was sent from. */
     get channel(): T extends AnyTextChannelWithoutGroup ? T : undefined {
-        return this._cachedChannel ?? (this._cachedChannel = this.client.getChannel(this.channelID) as T extends AnyTextChannelWithoutGroup ? T : undefined);
+        return this._cachedChannel ??= this.client.getChannel(this.channelID) as T extends AnyTextChannelWithoutGroup ? T : undefined;
     }
 
     /** The guild this interaction was sent from, if applicable. This will throw an error if the guild is not cached. */

--- a/lib/structures/StageInstance.ts
+++ b/lib/structures/StageInstance.ts
@@ -56,7 +56,7 @@ export default class StageInstance extends Base {
 
     /** The associated stage channel. */
     get channel(): StageChannel | undefined {
-        return this._cachedChannel ?? (this._cachedChannel = this.client.getChannel<StageChannel>(this.channelID));
+        return this._cachedChannel ??= this.client.getChannel<StageChannel>(this.channelID);
     }
 
     /** The guild of the associated stage channel. This will throw an error if the guild is not cached. */

--- a/lib/structures/VoiceState.ts
+++ b/lib/structures/VoiceState.ts
@@ -96,8 +96,8 @@ export default class VoiceState extends Base {
 
     /** The channel the user is connected to. */
     get channel(): VoiceChannel | StageChannel | null | undefined {
-        if (this.channelID !== null && this._cachedChannel === null) {
-            return this._cachedChannel ?? (this._cachedChannel = this.client.getChannel<VoiceChannel | StageChannel>(this.channelID));
+        if (this.channelID !== null) {
+            return this._cachedChannel ??= this.client.getChannel<VoiceChannel | StageChannel>(this.channelID);
         }
 
         return this._cachedChannel === null ? this._cachedChannel : (this._cachedChannel = null);

--- a/lib/structures/VoiceState.ts
+++ b/lib/structures/VoiceState.ts
@@ -96,7 +96,7 @@ export default class VoiceState extends Base {
 
     /** The channel the user is connected to. */
     get channel(): VoiceChannel | StageChannel | null | undefined {
-        if (this.channelID !== null && this._cachedChannel !== null) {
+        if (this.channelID !== null && this._cachedChannel === null) {
             return this._cachedChannel ?? (this._cachedChannel = this.client.getChannel<VoiceChannel | StageChannel>(this.channelID));
         }
 

--- a/lib/structures/Webhook.ts
+++ b/lib/structures/Webhook.ts
@@ -62,8 +62,8 @@ export default class Webhook extends Base {
 
     /** The channel this webhook is for, if applicable. */
     get channel(): AnyGuildTextChannel | null | undefined {
-        if (this.channelID !== null && this._cachedChannel !== null) {
-            return this._cachedChannel ?? (this._cachedChannel = this.client.getChannel<AnyGuildTextChannel>(this.channelID));
+        if (this.channelID !== null) {
+            return this._cachedChannel ??= this.client.getChannel<AnyGuildTextChannel>(this.channelID);
         }
 
         return this._cachedChannel === null ? this._cachedChannel : (this._cachedChannel = null);


### PR DESCRIPTION
In some cases, for example when leaving/joining a voice channel, `VoiceState#channel` always returns `null` because `_cachedChannel` never gets defined. This should (hopefully) alleviate that.