### PR TITLE
fix: add compress query param in resumeURL

### DIFF
--- a/lib/gateway/Shard.ts
+++ b/lib/gateway/Shard.ts
@@ -886,6 +886,9 @@ export default class Shard extends TypedEmitter<ShardEvents> {
                     url += "/";
                 }
                 this.resumeURL = `${url}?v=${GATEWAY_VERSION}&encoding=${Erlpack ? "etf" : "json"}`;
+                if (this.client.shards.options.compress) {
+                    this.resumeURL += "&compress=zlib-stream";
+                }
                 this.sessionID = packet.d.session_id;
 
                 for (const guild of packet.d.guilds) {


### PR DESCRIPTION
Adds the `compress=zlib-stream` query param in the resume url, if zlib compression is enabled.

Without this parameter, the discord sends uncompressed packets when connecting to the resume gateway url, so the Oceanic cannot process the packets because it tries to decompress uncompressed packets.