### PR TITLE
purge cached channel when channelID update

### DIFF
--- a/lib/structures/VoiceState.ts
+++ b/lib/structures/VoiceState.ts
@@ -58,6 +58,7 @@ export default class VoiceState extends Base {
     protected override update(data: Partial<RawVoiceState>): void {
         if (data.channel_id !== undefined) {
             this.channelID = data.channel_id;
+            this._cachedChannel = null;
         }
         if (data.deaf !== undefined) {
             this.deaf = data.deaf;


### PR DESCRIPTION
currently, when the voice state is updated and the conncting voice channel has been changed, `VoiceState#channel` will still return the cached and old voice channel.
This PR fixes the above behavior by deleting the cached voice channel when called `VoiceState#update()`.
This also fixes an issue that `voiceChannelSwitch`'s 2nd and 3rd parameters are the same.