### PR TITLE
Fix callback in request handler not being called on non-timeout errors

### DIFF
--- a/lib/rest/RequestHandler.ts
+++ b/lib/rest/RequestHandler.ts
@@ -287,8 +287,8 @@ export default class RequestHandler {
                     cb();
                     resolve(resBody as T);
                 } catch (err) {
+                    cb();
                     if (err instanceof Error && err.constructor.name === "DOMException" && err.name === "AbortError") {
-                        cb();
                         reject(new Error(`Request Timed Out (>${this.options.requestTimeout}ms) on ${options.method} ${options.path}`));
                     }
                     this.#manager.client.emit("error", err as Error);


### PR DESCRIPTION
Fixes #71. The callback never being called meant that the SequentialBucket couldn't continue, thus causing all future requests to never be handled.