### PR TITLE
Make User#tag return unique username instead of display name

### DIFF
--- a/lib/structures/User.ts
+++ b/lib/structures/User.ts
@@ -89,7 +89,7 @@ export default class User extends Base {
     /** This user's unique username, if migrated, else a combination of the user's username and discriminator. */
     get tag(): string {
         if (this.isMigrated) {
-            return this.username!;
+            return this.username;
         }
         return `${this.username}#${this.discriminator}`;
     }

--- a/lib/structures/User.ts
+++ b/lib/structures/User.ts
@@ -68,7 +68,7 @@ export default class User extends Base {
         }
     }
 
-    /** Whether this user has migrated to the new username system */
+    /** If this user has migrated to the new username system. */
     get isMigrated(): boolean {
         return this.globalName !== null && (this.discriminator === undefined || this.discriminator === "0");
     }

--- a/lib/structures/User.ts
+++ b/lib/structures/User.ts
@@ -68,7 +68,8 @@ export default class User extends Base {
         }
     }
 
-    private get isMigrated(): boolean {
+    /** Whether this user has migrated to the new username system */
+    get isMigrated(): boolean {
         return this.globalName !== null && (this.discriminator === undefined || this.discriminator === "0");
     }
 
@@ -85,10 +86,10 @@ export default class User extends Base {
         return `<@${this.id}>`;
     }
 
-    /** This user's display name, if migrated, else a combination of the user's username and discriminator. */
+    /** This user's unique username, if migrated, else a combination of the user's username and discriminator. */
     get tag(): string {
         if (this.isMigrated) {
-            return this.globalName!;
+            return this.username!;
         }
         return `${this.username}#${this.discriminator}`;
     }

--- a/lib/structures/User.ts
+++ b/lib/structures/User.ts
@@ -68,17 +68,17 @@ export default class User extends Base {
         }
     }
 
-    /** If this user has migrated to the new username system. */
-    get isMigrated(): boolean {
-        return this.globalName !== null && (this.discriminator === undefined || this.discriminator === "0");
-    }
-
     /** The default avatar value of this user. */
     get defaultAvatar(): number {
         if (this.isMigrated) {
             return Number(BigInt(this.id) >> 22n) % 6;
         }
         return Number(this.discriminator) % 5;
+    }
+
+    /** If this user has migrated to the new username system. */
+    get isMigrated(): boolean {
+        return this.globalName !== null && (this.discriminator === undefined || this.discriminator === "0");
     }
 
     /** A string that will mention this user. */


### PR DESCRIPTION
the point of .tag previously was to get the unique username you can use to add people (username + discrim), so for migrated users, it is logical to also return their unique username. Returning the non unique global displayName makes no sense to me. If people wanted that, they would instead use user.displayName

Also made isMigrated public because it's useful for libvrary users