### PR TITLE
Fix InteractionOptionsWrapper#getMentionable to correctly present user or role

### DIFF
--- a/lib/util/InteractionOptionsWrapper.ts
+++ b/lib/util/InteractionOptionsWrapper.ts
@@ -235,13 +235,13 @@ export default class InteractionOptionsWrapper {
             throw new WrapperError(`Value not present for required option: ${name}`);
         }
 		
-		if (role) {
-			return role;
-		} else if (user) {
-			return user;
-		} else {
-			return undefined;
-		};
+				if (role) {
+						return role;
+				} else if (user) {
+						return user;
+				} else {
+						return undefined;
+				}
     }
 
     /**

--- a/lib/util/InteractionOptionsWrapper.ts
+++ b/lib/util/InteractionOptionsWrapper.ts
@@ -234,14 +234,12 @@ export default class InteractionOptionsWrapper {
         if ((!role && !user) && required) {
             throw new WrapperError(`Value not present for required option: ${name}`);
         }
-		
-				if (role) {
-						return role;
-				} else if (user) {
-						return user;
-				} else {
-						return undefined;
-				}
+
+        if (role) {
+            return role;
+        } else if (user) {
+            return user;
+        }
     }
 
     /**

--- a/lib/util/InteractionOptionsWrapper.ts
+++ b/lib/util/InteractionOptionsWrapper.ts
@@ -235,11 +235,7 @@ export default class InteractionOptionsWrapper {
             throw new WrapperError(`Value not present for required option: ${name}`);
         }
 
-        if (role) {
-            return role;
-        } else if (user) {
-            return user;
-        }
+        return role ?? user;
     }
 
     /**

--- a/lib/util/InteractionOptionsWrapper.ts
+++ b/lib/util/InteractionOptionsWrapper.ts
@@ -214,12 +214,12 @@ export default class InteractionOptionsWrapper {
     }
 
     /**
-     * Get a mentionable option value (channel, user, role).
+     * Get a mentionable option value (user, role).
      * @param name The name of the option.
      * @param required If true, an error will be thrown if the option is not present, or if the value cannot be found.
      */
-    getMentionable<T extends InteractionResolvedChannel | User | Role = InteractionResolvedChannel | User | Role>(name: string, required?: false): T | undefined;
-    getMentionable<T extends InteractionResolvedChannel | User | Role = InteractionResolvedChannel | User | Role>(name: string, required: true): T;
+    getMentionable<T extends User | Role = User | Role>(name: string, required?: false): T | undefined;
+    getMentionable<T extends User | Role = User | Role>(name: string, required: true): T;
     getMentionable(name: string, required?: boolean): InteractionResolvedChannel | User | Role | undefined {
         if (this.resolved === null) {
             throw new TypeError("Attempt to use getMentionable with null resolved. If this is on an autocomplete interaction, use getAttachmentOption instead.");
@@ -229,13 +229,19 @@ export default class InteractionOptionsWrapper {
         if (!(val = (this._getOption(name, required as false, ApplicationCommandOptionTypes.MENTIONABLE) as InteractionOptionsMentionable | undefined)?.value)) {
             return undefined;
         }
-        const ch = this.resolved.channels.get(val);
         const role = this.resolved.roles.get(val);
         const user = this.resolved.users.get(val);
-        if ((!ch && !role && !user) && required) {
+        if ((!role && !user) && required) {
             throw new WrapperError(`Value not present for required option: ${name}`);
         }
-        return ch;
+		
+		if (role) {
+			return role;
+		} else if (user) {
+			return user;
+		} else {
+			return undefined;
+		};
     }
 
     /**

--- a/lib/util/SelectMenuValuesWrapper.ts
+++ b/lib/util/SelectMenuValuesWrapper.ts
@@ -71,23 +71,22 @@ export default class SelectMenuValuesWrapper {
     }
 
     /**
-     * Get the selected mentionables. (channels, users, roles)
+     * Get the selected mentionables. (users, roles)
      *
      * If `ensurePresent` is false, mentionables that aren't in resolved will be ignored.
-     * @param ensurePresent If true, an error will be thrown if any value cannot be mapped to a channel, user, or role.
+     * @param ensurePresent If true, an error will be thrown if any value cannot be mapped to a user, or role.
      */
-    getMentionables(ensurePresent?: boolean): Array<InteractionResolvedChannel | User | Role> {
-        const res: Array<InteractionResolvedChannel | User | Role> = [];
+    getMentionables(ensurePresent?: boolean): Array<User | Role> {
+        const res: Array<User | Role> = [];
         for (const id of this.raw) {
-            const ch = this.resolved.channels.get(id);
             const role = this.resolved.roles.get(id);
             const user = this.resolved.users.get(id);
-            if ((!ch && !role && !user)) {
+            if ((!role && !user)) {
                 if (ensurePresent) {
                     throw new WrapperError(`Failed to find mentionable in resolved data: ${id}`);
                 }
             } else {
-                res.push((ch ?? role ?? user)!);
+                res.push((role ?? user)!);
             }
         }
 


### PR DESCRIPTION
The `getMentionable` function never returns users or roles; it only returns channels, which should not be included in the **Mentionable**.