### PR TITLE
fix: temp workaround for pako compression

### DIFF
--- a/lib/gateway/Shard.ts
+++ b/lib/gateway/Shard.ts
@@ -1392,7 +1392,7 @@ export default class Shard extends TypedEmitter<ShardEvents> {
                     if (currentPointer === undefined) {
                         // decompression support by zlib-sync
                         data = Buffer.from(this.#sharedZLib.result ?? "");
-                    } else if (this.#sharedZLib.chunks.length === 0){
+                    } else if (this.#sharedZLib.chunks.length === 0) {
                         // decompression support by pako. The current buffer hasn't been flushed
                         data = this.#sharedZLib.strm!.output.slice(currentPointer);
                     } else {

--- a/lib/gateway/Shard.ts
+++ b/lib/gateway/Shard.ts
@@ -1380,7 +1380,10 @@ export default class Shard extends TypedEmitter<ShardEvents> {
             assert(is<Buffer>(data));
             if (this.client.shards.options.compress) {
                 if (data.length >= 4 && data.readUInt32BE(data.length - 4) === 0xFFFF) {
-                // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
+                    // store the current pointer for slicing buffers after pushing.
+                    // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-member-access
+                    const currentPointer: number | undefined = this.#sharedZLib.strm?.next_out;
+                    // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
                     this.#sharedZLib.push(data, zlibConstants!.Z_SYNC_FLUSH);
                     // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
                     if (this.#sharedZLib.err) {
@@ -1389,8 +1392,28 @@ export default class Shard extends TypedEmitter<ShardEvents> {
                         return;
                     }
 
-                    // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-argument
-                    data = Buffer.from(this.#sharedZLib.result ?? "");
+                    if (currentPointer === undefined){
+                        // decompression support by zlib-sync
+                        // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-argument
+                        data = Buffer.from(this.#sharedZLib.result ?? "");
+                    // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
+                    } else if (this.#sharedZLib.chunks.length === 0){
+                        // decompression support by pako. The current buffer hasn't been flushed
+                        // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
+                        data = this.#sharedZLib.strm!.output.slice(currentPointer);
+                    } else {
+                        // decompression support by pako. Buffers have been flushed once or more times.
+                        data = Buffer.concat([
+                            // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
+                            this.#sharedZLib.chunks[0].slice(currentPointer),
+                            // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
+                            ...this.#sharedZLib.chunks.slice(1),
+                            // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
+                            this.#sharedZLib.strm.output
+                        ]);
+                        // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
+                        this.#sharedZLib.chunks = [];
+                    }
                     // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
                     return this.onPacket((Erlpack ? Erlpack.unpack(data as Buffer) : JSON.parse(data.toString())) as AnyReceivePacket);
                 } else {

--- a/lib/gateway/Shard.ts
+++ b/lib/gateway/Shard.ts
@@ -1363,6 +1363,7 @@ export default class Shard extends TypedEmitter<ShardEvents> {
         this.client.emit("error", err, this.id);
     }
 
+    /* eslint-disable @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call, @typescript-eslint/restrict-template-expressions, @typescript-eslint/no-unsafe-argument */
     private onWSMessage(data: Data): void {
         if (typeof data === "string") {
             data = Buffer.from(data);
@@ -1381,56 +1382,42 @@ export default class Shard extends TypedEmitter<ShardEvents> {
             if (this.client.shards.options.compress) {
                 if (data.length >= 4 && data.readUInt32BE(data.length - 4) === 0xFFFF) {
                     // store the current pointer for slicing buffers after pushing.
-                    // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-member-access
                     const currentPointer: number | undefined = this.#sharedZLib.strm?.next_out;
-                    // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
                     this.#sharedZLib.push(data, zlibConstants!.Z_SYNC_FLUSH);
-                    // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
                     if (this.#sharedZLib.err) {
-                    // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/restrict-template-expressions
                         this.client.emit("error", new GatewayError(`zlib error ${this.#sharedZLib.err}: ${this.#sharedZLib.msg ?? ""}`, 0));
                         return;
                     }
 
-                    if (currentPointer === undefined){
+                    if (currentPointer === undefined) {
                         // decompression support by zlib-sync
-                        // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-argument
                         data = Buffer.from(this.#sharedZLib.result ?? "");
-                    // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
                     } else if (this.#sharedZLib.chunks.length === 0){
                         // decompression support by pako. The current buffer hasn't been flushed
-                        // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
                         data = this.#sharedZLib.strm!.output.slice(currentPointer);
                     } else {
                         // decompression support by pako. Buffers have been flushed once or more times.
                         data = Buffer.concat([
-                            // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
                             this.#sharedZLib.chunks[0].slice(currentPointer),
-                            // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
                             ...this.#sharedZLib.chunks.slice(1),
-                            // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
                             this.#sharedZLib.strm.output
                         ]);
-                        // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
                         this.#sharedZLib.chunks = [];
                     }
-                    // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
                     return this.onPacket((Erlpack ? Erlpack.unpack(data as Buffer) : JSON.parse(data.toString())) as AnyReceivePacket);
                 } else {
-                // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
                     this.#sharedZLib.push(data, false);
                 }
             } else if (Erlpack) {
-            // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
                 return this.onPacket(Erlpack.unpack(data) as AnyReceivePacket);
             } else {
                 return this.onPacket(JSON.parse(data.toString()) as AnyReceivePacket);
             }
-
         } catch (err) {
             this.client.emit("error", err as Error, this.id);
         }
     }
+    /* eslint-enable @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call, @typescript-eslint/restrict-template-expressions, @typescript-eslint/no-unsafe-argument */
 
     private onWSOpen(): void {
         this.status = "handshaking";


### PR DESCRIPTION
This workaround fixes the issue with pako and now we can use oceanic.js with pako's compression support.