### PR TITLE
Adds appliedTags to start thread opts

### DIFF
--- a/lib/routes/Channels.ts
+++ b/lib/routes/Channels.ts
@@ -1201,7 +1201,8 @@ export default class Channels {
                     sticker_ids:      options.message.stickerIDs
                 },
                 name:                options.name,
-                rate_limit_per_user: options.rateLimitPerUser
+                rate_limit_per_user: options.rateLimitPerUser,
+                applied_tags:        options.appliedTags
             },
             reason,
             files

--- a/lib/types/channels.d.ts
+++ b/lib/types/channels.d.ts
@@ -958,6 +958,8 @@ export interface StartThreadWithoutMessageOptions extends StartThreadFromMessage
 }
 
 export interface StartThreadInThreadOnlyChannelOptions extends StartThreadFromMessageOptions {
+    /** [Forum Channel Only] The IDs of up to 5 tags from the forum to apply to the thread. */
+    appliedTags?: Array<string>;
     /** The message to start the thread with. */
     message: ThreadOnlyChannelThreadStarterMessageOptions;
 }


### PR DESCRIPTION
Please let us add appliedtags in rest.channels#startThreadInThreadOnlyChannel, this is on discord specification: https://discord.com/developers/docs/resources/channel#start-thread-in-forum-or-media-channel-jsonform-params