### PR TITLE
Fix missing "custom_message" property on createAutoModerationRule

### DIFF
--- a/lib/routes/Guilds.ts
+++ b/lib/routes/Guilds.ts
@@ -209,6 +209,7 @@ export default class Guilds {
                 actions: options.actions.map(a => ({
                     metadata: {
                         channel_id:       a.metadata.channelID,
+                        custom_message:   a.metadata.customMessage,
                         duration_seconds: a.metadata.durationSeconds
                     },
                     type: a.type


### PR DESCRIPTION
The "custom_message" property of the metadata is not included in the actions of the createAutoModerationRule function.