### PR TITLE
fix UncachedError on VOICE_STATE_UPDATE

### DIFF
--- a/lib/gateway/Shard.ts
+++ b/lib/gateway/Shard.ts
@@ -1163,7 +1163,7 @@ export default class Shard extends TypedEmitter<ShardEvents> {
                 const guild = this.client.guilds.get(packet.d.guild_id);
                 const member = this.client.util.updateMember(packet.d.guild_id, packet.d.user_id, packet.d.member);
 
-                const oldState = member.voiceState?.toJSON() ?? null;
+                const oldState = guild?.voiceStates.get(member.id)?.toJSON() ?? null;
                 const state = guild?.voiceStates.update({ ...packet.d, id: member.id }) ?? new VoiceState(packet.d, this.client);
                 member["update"]({ deaf: state.deaf, mute: state.mute });
 


### PR DESCRIPTION
Hello,
I noticed that when disabling cache, on dispatch of a VOICE_STATE_UPDATE event, oceanic will systematically throw a UncachedError (UncachedError: Member#guild is not present.)

I looked through the source code and found that in order to get the `oldState`, `member.voiceState()` is called, and this method itself calls member.guild (and it throws the error)

So I proposed to instead directly call `guild?.voiceStates.get(member.id)?` so that if guild is not cached, oldState will simply default to `null` and avoid throwing error