### PR TITLE
fix voiceChannelLeave event on no cache

### DIFF
--- a/lib/gateway/Shard.ts
+++ b/lib/gateway/Shard.ts
@@ -1181,7 +1181,7 @@ export default class Shard extends TypedEmitter<ShardEvents> {
                         this.client.emit("voiceChannelSwitch", member, newChannel, oldChannel);
                     } else if (newChannel) {
                         this.client.emit("voiceChannelJoin", member, newChannel);
-                    } else if (oldChannel) {
+                    } else if (state.channelID === null) {
                         this.client.emit("voiceChannelLeave", member, oldChannel);
                     }
                 }

--- a/lib/types/events.d.ts
+++ b/lib/types/events.d.ts
@@ -229,7 +229,7 @@ export interface ClientEvents {
     /** @event Emitted when a user joins a voice channel. Requires the `GUILD_VOICE_STATES` intent. */
     voiceChannelJoin: [member: Member, channel: VoiceChannel | StageChannel | Uncached];
     /** @event Emitted when a user leaves a voice channel. Requires the `GUILD_VOICE_STATES` intent. */
-    voiceChannelLeave: [member: Member, channel: VoiceChannel | StageChannel | Uncached];
+    voiceChannelLeave: [member: Member, channel: VoiceChannel | StageChannel | Uncached | null];
     /** @event Emitted when a voice channel's status is updated. Requires the `GUILD_VOICE_STATES` intent. */
     voiceChannelStatusUpdate: [channel: VoiceChannel | Uncached, status: string | null];
     /** @event Emitted when a user switches voice channels. Requires the `GUILD_VOICE_STATES` intent. */


### PR DESCRIPTION
hello,

when caching is disabled, the `voiceChannelLeave` event does not emit at all. that's because the event is only emitted if the cached value `oldChannel` is defined. instead, I propose to directly check if the `state.channelID` is null, so the event doesn't have to depend on whether the *old voice state* and the *old channel* are cached.

when the old channel is not cached, it will pass `null` as the value for the `oldChannel` event parameter, so I updated its type accordingly

thanks