### PR TITLE
Fix messageReactionAdd message author when message is uncached

### DIFF
--- a/lib/gateway/Shard.ts
+++ b/lib/gateway/Shard.ts
@@ -755,7 +755,7 @@ export default class Shard extends TypedEmitter<ShardEvents> {
                     guild,
                     guildID:   packet.d.guild_id,
                     id:        packet.d.message_id ,
-                    author:    packet.d.message_author_id === undefined ? undefined : guild?.members.get(packet.d.user_id) ?? this.client.users.get(packet.d.user_id) ?? { id: packet.d.message_author_id }
+                    author:    packet.d.message_author_id === undefined ? undefined : guild?.members.get(packet.d.message_author_id) ?? this.client.users.get(packet.d.message_author_id) ?? { id: packet.d.message_author_id }
                 }, reactor, packet.d.emoji, packet.d.burst);
                 break;
             }


### PR DESCRIPTION
When the message is not cached, the user ID used to get the author of the message is the user ID of the user who reacted to the message instead of the user ID of the author of the message.