### PR TITLE
Support for application emojis

### DIFF
--- a/lib/gateway/Shard.ts
+++ b/lib/gateway/Shard.ts
@@ -429,7 +429,7 @@ export default class Shard extends TypedEmitter<ShardEvents> {
                 this.client.emit(
                     "guildEmojisUpdate",
                     guild ?? { id: packet.d.guild_id },
-                    guild?.emojis?.toArray() ?? packet.d.emojis.map(emoji => this.client.util.convertEmoji(emoji)),
+                    guild?.emojis?.toArray() ?? packet.d.emojis.map(emoji => this.client.util.convertGuildEmoji(emoji)),
                     oldEmojis
                 );
                 break;

--- a/lib/routes/Guilds.ts
+++ b/lib/routes/Guilds.ts
@@ -1,8 +1,8 @@
 /** @module REST/Guilds */
 import type {
-    CreateEmojiOptions,
+    CreateGuildEmojiOptions,
     CreateGuildOptions,
-    EditEmojiOptions,
+    EditGuildEmojiOptions,
     EditGuildOptions,
     GuildEmoji,
     ModifyChannelPositionsEntry,
@@ -334,7 +334,7 @@ export default class Guilds {
      * @caching This method **may** cache its result. The result will not be cached if the guild is not cached.
      * @caches {@link Guild#emojis | Guild#emojis}<br>{@link Client#users | Client#users} (creator, if applicable)
      */
-    async createEmoji(guildID: string, options: CreateEmojiOptions): Promise<GuildEmoji> {
+    async createEmoji(guildID: string, options: CreateGuildEmojiOptions): Promise<GuildEmoji> {
         const reason = options.reason;
         if (options.reason) {
             delete options.reason;
@@ -351,7 +351,7 @@ export default class Guilds {
                 roles: options.roles
             },
             reason
-        }).then(data => this._manager.client.guilds.get(guildID)?.emojis.update(data) ?? this._manager.client.util.convertEmoji(data));
+        }).then(data => this._manager.client.guilds.get(guildID)?.emojis.update(data) ?? this._manager.client.util.convertGuildEmoji(data));
     }
 
     /**
@@ -767,7 +767,7 @@ export default class Guilds {
      * @caching This method **may** cache its result. The result will not be cached if the guild is not cached.
      * @caches {@link Guild#emojis | Guild#emojis}
      */
-    async editEmoji(guildID: string, emojiID: string, options: EditEmojiOptions): Promise<GuildEmoji> {
+    async editEmoji(guildID: string, emojiID: string, options: EditGuildEmojiOptions): Promise<GuildEmoji> {
         const reason = options.reason;
         if (options.reason) {
             delete options.reason;
@@ -780,7 +780,7 @@ export default class Guilds {
                 roles: options.roles
             },
             reason
-        }).then(data => this._manager.client.guilds.get(guildID)?.emojis.update(data) ?? this._manager.client.util.convertEmoji(data));
+        }).then(data => this._manager.client.guilds.get(guildID)?.emojis.update(data) ?? this._manager.client.util.convertGuildEmoji(data));
     }
 
     /**
@@ -1337,7 +1337,7 @@ export default class Guilds {
         return this._manager.authRequest<RawGuildEmoji>({
             method: "GET",
             path:   Routes.GUILD_EMOJI(guildID, emojiID)
-        }).then(data => this._manager.client.guilds.get(guildID)?.emojis.update(data) ?? this._manager.client.util.convertEmoji(data));
+        }).then(data => this._manager.client.guilds.get(guildID)?.emojis.update(data) ?? this._manager.client.util.convertGuildEmoji(data));
     }
 
     /**
@@ -1353,7 +1353,7 @@ export default class Guilds {
         }).then(data => {
             const guild = this._manager.client.guilds.get(guildID);
             guild?.emojis.clear();
-            return data.map(emoji => guild?.emojis.update(emoji) ?? this._manager.client.util.convertEmoji(emoji));
+            return data.map(emoji => guild?.emojis.update(emoji) ?? this._manager.client.util.convertGuildEmoji(emoji));
         });
     }
 

--- a/lib/structures/ClientApplication.ts
+++ b/lib/structures/ClientApplication.ts
@@ -23,7 +23,11 @@ import type {
     RawTestEntitlement,
     SearchEntitlementsOptions,
     RawClientApplication,
-    EditApplicationOptions
+    EditApplicationOptions,
+    ApplicationEmoji,
+    ApplicationEmojis,
+    CreateApplicationEmojiOptions,
+    EditApplicationEmojiOptions
 } from "../types/applications";
 import type { JSONClientApplication } from "../types/json";
 import type { ApplicationCommandTypes } from "../Constants";
@@ -82,6 +86,15 @@ export default class ClientApplication extends Base {
     }
 
     /**
+     * Create an emoji for this application.
+     * @param options The options for creating the emoji.
+     * @caching This method **does not** cache its result.
+     */
+    async createEmoji(options: CreateApplicationEmojiOptions): Promise<ApplicationEmoji> {
+        return this.client.rest.applications.createEmoji(this.id, options);
+    }
+
+    /**
      * Create a global application command.
      * @param options The options for creating the command.
      */
@@ -104,6 +117,14 @@ export default class ClientApplication extends Base {
      */
     async createTestEntitlement(options: CreateTestEntitlementOptions): Promise<TestEntitlement> {
         return this.client.rest.applications.createTestEntitlement(this.id, options);
+    }
+    /**
+     * Delete an emoji for this application.
+     * @param emojiID The ID of the emoji to be deleted.
+     * @caching This method **does not** cache its result.
+     */
+    async deleteEmoji(emojiID: string): Promise<void> {
+        return this.client.rest.applications.deleteEmoji(this.id, emojiID);
     }
 
     /**
@@ -140,6 +161,16 @@ export default class ClientApplication extends Base {
     }
 
     /**
+     * Edit an existing emoji for this application.
+     * @param emojiID The ID of the emoji to be edited.
+     * @param options The options for editing the emoji.
+     * @caching This method **does not** cache its result.
+     */
+    async editEmoji(emojiID: string, options: EditApplicationEmojiOptions): Promise<ApplicationEmoji> {
+        return this.client.rest.applications.editEmoji(this.id, emojiID, options);
+    }
+
+    /**
      * Edit a global application command.
      * @param commandID The ID of the command.
      * @param options The options for editing the command.
@@ -166,6 +197,21 @@ export default class ClientApplication extends Base {
      */
     async editGuildCommandPermissions(guildID: string, commandID: string, options: EditApplicationCommandPermissionsOptions): Promise<RESTGuildApplicationCommandPermissions> {
         return this.client.rest.applications.editGuildCommandPermissions(this.id, guildID, commandID, options);
+    }
+
+    /**
+     * Get an emoji for this application.
+     * @param emojiID The ID of the emoji to get.
+     */
+    async getEmoji(emojiID: string): Promise<ApplicationEmoji> {
+        return this.client.rest.applications.getEmoji(this.id, emojiID);
+    }
+
+    /**
+     * Get the emojis for this application.
+     */
+    async getEmojis(): Promise<ApplicationEmojis> {
+        return this.client.rest.applications.getEmojis(this.id);
     }
 
     /**

--- a/lib/structures/Guild.ts
+++ b/lib/structures/Guild.ts
@@ -59,11 +59,11 @@ import type {
     BeginPruneOptions,
     CreateBanOptions,
     CreateChannelOptions,
-    CreateEmojiOptions,
+    CreateGuildEmojiOptions,
     CreateRoleOptions,
     EditCurrentMemberOptions,
     EditCurrentUserVoiceStateOptions,
-    EditEmojiOptions,
+    EditGuildEmojiOptions,
     EditGuildOptions,
     EditMemberOptions,
     EditRoleOptions,
@@ -277,7 +277,7 @@ export default class Guild extends Base {
         this.defaultMessageNotifications = data.default_message_notifications;
         this.description = null;
         this.discoverySplash = null;
-        this.emojis = new SimpleCollection(rawEmoji => this.client.util.convertEmoji(rawEmoji), client.util._getLimit("emojis", this.id), "merge");
+        this.emojis = new SimpleCollection(rawEmoji => this.client.util.convertGuildEmoji(rawEmoji), client.util._getLimit("emojis", this.id), "merge");
         this.explicitContentFilter = data.explicit_content_filter;
         this.features = [];
         this.icon = null;
@@ -759,7 +759,7 @@ export default class Guild extends Base {
      * Create an emoji in this guild.
      * @param options The options for creating the emoji.
      */
-    async createEmoji(options: CreateEmojiOptions): Promise<GuildEmoji> {
+    async createEmoji(options: CreateGuildEmojiOptions): Promise<GuildEmoji> {
         return this.client.rest.guilds.createEmoji(this.id, options);
     }
 
@@ -965,7 +965,7 @@ export default class Guild extends Base {
      * Edit an existing emoji in this guild.
      * @param options The options for editing the emoji.
      */
-    async editEmoji(emojiID: string, options: EditEmojiOptions): Promise<GuildEmoji> {
+    async editEmoji(emojiID: string, options: EditGuildEmojiOptions): Promise<GuildEmoji> {
         return this.client.rest.guilds.editEmoji(this.id, emojiID, options);
     }
 

--- a/lib/types/applications.d.ts
+++ b/lib/types/applications.d.ts
@@ -1,7 +1,7 @@
 /** @module Types/Applications */
 import type { ImplementedChannels, InstallParams, RawOAuthGuild, RawUser } from ".";
 import type { ExclusifyUnion } from "./shared";
-import type { WithRequired } from "./misc";
+import type { Emoji, WithRequired } from "./misc";
 import type {
     ApplicationCommandOptionTypes,
     ApplicationCommandPermissionTypes,
@@ -463,4 +463,26 @@ export interface EditApplicationOptions {
     roleConnectionsVerificationURL?: string;
     /** The tags for the application. Max 5 per application, 20 characters each. */
     tags?: Array<string>;
+}
+
+export interface RawApplicationEmoji extends Required<Omit<Emoji, "user" | "id">>  { id: string; user?: RawUser; }
+export interface ApplicationEmoji extends Omit<RawApplicationEmoji, "user" | "id" | "require_colons"> { id: string; requireColons?: boolean; user?: User; }
+
+export interface RawApplicationEmojis {
+    items: Array<RawApplicationEmoji>;
+}
+
+export interface ApplicationEmojis {
+    items: Array<ApplicationEmoji>;
+}
+
+export interface CreateApplicationEmojiOptions {
+    /** The image (buffer, or full data url). */
+    image: Buffer | string;
+    /** The name of the emoji (must be unique). */
+    name: string;
+}
+
+export interface EditApplicationEmojiOptions {
+    name: string;
 }

--- a/lib/types/guilds.d.ts
+++ b/lib/types/guilds.d.ts
@@ -15,6 +15,7 @@ import type { RawScheduledEvent } from "./scheduled-events";
 import type { ClientStatus, PresenceUpdate, Activity as GatewayActivity } from "./gateway";
 import type { RawVoiceState } from "./voice";
 import { type File } from "./request-handler";
+import type { Emoji } from "./misc";
 import type {
     ChannelTypes,
     DefaultMessageNotificationLevels,
@@ -131,16 +132,6 @@ export interface RoleTags {
     integrationID?: string;
     premiumSubscriber: boolean;
     subscriptionListingID?: string;
-}
-export interface Emoji {
-    animated?: boolean;
-    available?: boolean;
-    id: string | null;
-    managed?: boolean;
-    name: string;
-    require_colons?: boolean;
-    roles?: Array<string>;
-    user?: RawUser;
 }
 export interface RawGuildEmoji extends Required<Omit<Emoji, "user" | "id">>  { id: string; user?: RawUser; }
 export interface GuildEmoji extends Omit<RawGuildEmoji, "user" | "id" | "require_colons"> { id: string; requireColons?: boolean; user?: User; }
@@ -262,7 +253,7 @@ export interface NullablePartialEmoji {
     name?: string | null;
 }
 
-export interface CreateEmojiOptions {
+export interface CreateGuildEmojiOptions {
     /** The image (buffer, or full data url). */
     image: Buffer | string;
     /** The name of the emoji. */
@@ -273,7 +264,7 @@ export interface CreateEmojiOptions {
     roles?: Array<string>;
 }
 
-export interface EditEmojiOptions {
+export interface EditGuildEmojiOptions {
     /** The name of the emoji. */
     name?: string;
     /** The reason for creating the emoji. */

--- a/lib/types/misc.d.ts
+++ b/lib/types/misc.d.ts
@@ -1,6 +1,7 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 /** @module Types/Miscellaneous */
 
+import type { RawUser } from "./users";
 import type Client from "../Client";
 
 export type StringMap<T extends Record<string, any>> = { [K in keyof T]: `${T[K]}` };
@@ -25,4 +26,15 @@ export interface RefreshAttachmentURLsResponse {
 export interface RefreshedAttachment {
     original: string;
     refreshed: string;
+}
+
+export interface Emoji {
+    animated?: boolean;
+    available?: boolean;
+    id: string | null;
+    managed?: boolean;
+    name: string;
+    require_colons?: boolean;
+    roles?: Array<string>;
+    user?: RawUser;
 }

--- a/lib/util/Routes.ts
+++ b/lib/util/Routes.ts
@@ -149,6 +149,8 @@ export const ENTITLEMENTS                          = (applicationID: string) => 
 export const ENTITLEMENT                           = (applicationID: string, entitlementID: string) => encode`/applications/${applicationID}/entitlements/${entitlementID}`;
 export const CONSUME_ENTITLEMENT                   = (applicationID: string, entitlementID: string) => encode`/applications/${applicationID}/entitlements/${entitlementID}/consume`;
 export const SKUS                                  = (applicationID: string) => encode`/applications/${applicationID}/skus`;
+export const APPLICATION_EMOJIS                    = (applicationID: string) => encode`/applications/${applicationID}/emojis`;
+export const APPLICATION_EMOJI                     = (applicationID: string, emojiID: string) => encode`/applications/${applicationID}/emojis/${emojiID}`;
 
 // Misc
 export const GATEWAY                   = "/gateway";

--- a/lib/util/Util.ts
+++ b/lib/util/Util.ts
@@ -62,7 +62,9 @@ import type {
     Uncached,
     RawBaseEntitlement,
     RawEntitlement,
-    RawTestEntitlement
+    RawTestEntitlement,
+    ApplicationEmoji,
+    RawApplicationEmoji
 } from "../types";
 import Message from "../structures/Message";
 import Entitlement from "../structures/Entitlement";
@@ -278,7 +280,11 @@ export default class Util {
         })) as never;
     }
 
-    convertEmoji(raw: RawGuildEmoji): GuildEmoji {
+    convertApplicationEmoji(raw: RawApplicationEmoji): ApplicationEmoji {
+        return this.convertGuildEmoji(raw);
+    }
+
+    convertGuildEmoji(raw: RawGuildEmoji): GuildEmoji {
         return {
             animated:      raw.animated,
             available:     raw.available,


### PR DESCRIPTION
Note: I didn't really know what to do in some places, and there ended up being breaking changes with function and type names. Also I don't know whether there should be a separate type for the application emoji without the user which is returned from requests which create or edit. Get requests seem to always return it; emojis uploaded by the bot itself have the bot user. Also require_colons should always be present, right? I don't know what historical reason it exists for and why it was sometimes not present in guild emojis. Right now ApplicationEmoji is a copy of GuildEmoji to make modifications easier.