### PR TITLE
Fix typo in Routes.GUILD_APPLICATION_COMMAND_PERMISSIONS

### DIFF
--- a/lib/util/Routes.ts
+++ b/lib/util/Routes.ts
@@ -143,7 +143,7 @@ export const APPLICATION_COMMANDS                  = (applicationID: string) => 
 export const GUILD_APPLICATION_COMMAND             = (applicationID: string, guildID: string, commandID: string) => encode`/applications/${applicationID}/guilds/${guildID}/commands/${commandID}`;
 export const GUILD_APPLICATION_COMMANDS            = (applicationID: string, guildID: string) => encode`/applications/${applicationID}/guilds/${guildID}/commands`;
 export const GUILD_APPLICATION_COMMAND_PERMISSION  = (applicationID: string, guildID: string, commandID: string) => encode`/applications/${applicationID}/guilds/${guildID}/commands/${commandID}/permissions`;
-export const GUILD_APPLICATION_COMMAND_PERMISSIONS = (applicationID: string, guildID: string) => encode`/applications/${applicationID}/guilds/${guildID}commands/permissions`;
+export const GUILD_APPLICATION_COMMAND_PERMISSIONS = (applicationID: string, guildID: string) => encode`/applications/${applicationID}/guilds/${guildID}/commands/permissions`;
 export const INTERACTION_CALLBACK                  = (interactionID: string, interactionToken: string) => encode`/interactions/${interactionID}/${interactionToken}/callback`;
 export const APPLICATION                           = "/applications/@me";
 export const ENTITLEMENTS                          = (applicationID: string) => encode`/applications/${applicationID}/entitlements`;


### PR DESCRIPTION
I was getting an error (DiscordRESTError: 404: Not Found on GET /api/v10/applications/`[REDACTED]`/guilds/`[REDACTED]`commands/permissions) when running `await interaction.client.rest.applications.getGuildPermissions()`. 

I investigated and found that there's a typo in the routes. This pull request fixes it.