### PR TITLE
Set allowed mentions on edit even if content string is empty or null

### DIFF
--- a/lib/routes/Channels.ts
+++ b/lib/routes/Channels.ts
@@ -63,6 +63,7 @@ import type User from "../structures/User";
 import type { Uncached } from "../types/shared";
 import type { CreateStageInstanceOptions, EditStageInstanceOptions, RawStageInstance } from "../types/guilds";
 import StageInstance from "../structures/StageInstance";
+import { MessageFlags } from "../Constants";
 
 /** Various methods for interacting with channels. Located at {@link Client#rest | Client#rest}{@link RESTManager#channels | .channels}. */
 export default class Channels {
@@ -480,12 +481,14 @@ export default class Channels {
             method: "PATCH",
             path:   Routes.CHANNEL_MESSAGE(channelID, messageID),
             json:   {
-                allowed_mentions: options.content !== undefined || options.allowedMentions ? this._manager.client.util.formatAllowedMentions(options.allowedMentions) : undefined,
-                attachments:      options.attachments,
-                components:       options.components ? this._manager.client.util.componentsToRaw(options.components) : undefined,
-                content:          options.content,
-                embeds:           options.embeds ? this._manager.client.util.embedsToRaw(options.embeds) : undefined,
-                flags:            options.flags
+                allowed_mentions: options.content !== undefined || options.allowedMentions || ((options.flags ?? 0) & MessageFlags.IS_COMPONENTS_V2) !== 0
+                    ? this._manager.client.util.formatAllowedMentions(options.allowedMentions)
+                    : undefined,
+                attachments: options.attachments,
+                components:  options.components ? this._manager.client.util.componentsToRaw(options.components) : undefined,
+                content:     options.content,
+                embeds:      options.embeds ? this._manager.client.util.embedsToRaw(options.embeds) : undefined,
+                flags:       options.flags
             },
             files
         }).then(data => this._manager.client.util.updateMessage<T>(data));

--- a/lib/routes/Channels.ts
+++ b/lib/routes/Channels.ts
@@ -480,7 +480,7 @@ export default class Channels {
             method: "PATCH",
             path:   Routes.CHANNEL_MESSAGE(channelID, messageID),
             json:   {
-                allowed_mentions: options.content || options.allowedMentions ? this._manager.client.util.formatAllowedMentions(options.allowedMentions) : undefined,
+                allowed_mentions: options.content !== undefined || options.allowedMentions ? this._manager.client.util.formatAllowedMentions(options.allowedMentions) : undefined,
                 attachments:      options.attachments,
                 components:       options.components ? this._manager.client.util.componentsToRaw(options.components) : undefined,
                 content:          options.content,


### PR DESCRIPTION
I promise this is my last allowedMentions PR. In my last PR, I assumed if the content is empty or null there is no point sending it as it will have no effect. But obviously, Discord is always recomputing mentions when content changes (as you can see by the fact empty content removes mentions) and there is at least one case where a message with empty content can ping - replies - which I forgot about.

I tested it with this before and after
```js
// pnpm prepare
// MY_TOKEN=blabla node
// const { Client } = require("./dist/lib");
const client = new Client({ auth: "Bot " + process.env.MY_TOKEN })
const message = await client.rest.channels.createMessage(
    "some_channel_id",
    { content: "Hello", messageReference: { messageID: "some_other_message" } }
);
await client.rest.channels.editMessage(
    message.channelID,
    message.id,
    { content: "", embeds: [{ title: "Hello", description: "hi" }] }
);
```
You'll see that after edit the reply ping is enabled

This change reflects how Eris does things: https://github.com/abalabahaha/eris/blob/ae295d081c17f574b3768f6d60fcd7dd1b64b54c/lib/Client.js#L2126. Eris also sets allowedMentions if embeds are set - I wonder why that is because embeds don't seem to cause mentions to be recomputed? Perhaps it wouldn't hurt?