### PR TITLE
Add invite types

### DIFF
--- a/lib/Constants.ts
+++ b/lib/Constants.ts
@@ -934,6 +934,12 @@ export enum InteractionTypes {
     MODAL_SUBMIT                     = 5,
 }
 
+export enum InviteTypes {
+    GUILD =     0,
+    GROUP_DM =  1,
+    FRIEND =    2,
+}
+
 export enum InviteTargetTypes {
     STREAM                      = 1,
     EMBEDDED_APPLICATION        = 2,

--- a/lib/Constants.ts
+++ b/lib/Constants.ts
@@ -387,7 +387,7 @@ export const TextableGuildChannelTypes = exclude(TextableChannelTypes, [ChannelT
 export const TextableChannelsWithoutThreadsTypes = exclude(TextableChannelTypes, ThreadChannelTypes);
 export const TextableGuildChannelsWithoutThreadsTypes = exclude(TextableGuildChannelTypes, ThreadChannelTypes);
 export const VoiceChannelTypes = [ChannelTypes.GUILD_VOICE, ChannelTypes.GUILD_STAGE_VOICE] as const;
-export const InviteChannelTypes = [ChannelTypes.GUILD_TEXT, ChannelTypes.GUILD_ANNOUNCEMENT, ...VoiceChannelTypes, ChannelTypes.GUILD_FORUM, ChannelTypes.GUILD_MEDIA] as const;
+export const InviteChannelTypes = [ChannelTypes.GUILD_TEXT, ChannelTypes.GUILD_ANNOUNCEMENT, ...VoiceChannelTypes, ChannelTypes.GUILD_FORUM, ChannelTypes.GUILD_MEDIA, ChannelTypes.GROUP_DM] as const;
 export const InteractionChannelTypes = [...TextableChannelTypes, ChannelTypes.GROUP_DM] as const;
 export const ThreadOnlyChannelTypes = [ChannelTypes.GUILD_FORUM, ChannelTypes.GUILD_MEDIA] as const;
 

--- a/lib/structures/Invite.ts
+++ b/lib/structures/Invite.ts
@@ -14,7 +14,7 @@ import type {
     RawInviteWithMetadata
 } from "../types/channels";
 import type Client from "../Client";
-import type { InviteTargetTypes } from "../Constants";
+import type { InviteTargetTypes, InviteTypes } from "../Constants";
 import type { JSONInvite } from "../types/json";
 import type { Uncached } from "../types/shared";
 
@@ -58,6 +58,8 @@ export default class Invite<T extends InviteInfoTypes = "withMetadata", CH exten
     targetUser?: User;
     /** If this invite only grants temporary membership. */
     temporary!: T extends "withMetadata" ? boolean : never;
+    /** The [type](https://discord.com/developers/docs/resources/invite#invite-object-invite-types) of this invite. */
+    type: InviteTypes;
     /** The number of times this invite has been used. */
     uses!: T extends "withMetadata" ? number : never;
     constructor(data: RawInvite | RawInviteWithMetadata, client: Client) {
@@ -74,6 +76,7 @@ export default class Invite<T extends InviteInfoTypes = "withMetadata", CH exten
         this.guildID = data.guild?.id ?? null;
         this.expiresAt = (data.expires_at ? new Date(data.expires_at) : undefined) as never;
         this.targetType = data.target_type;
+        this.type = data.type;
         this.update(data);
     }
 

--- a/lib/types/channels.d.ts
+++ b/lib/types/channels.d.ts
@@ -41,7 +41,8 @@ import type {
     ThreadOnlyChannelTypes,
     ReactionType,
     PollLayoutType,
-    SeparatorSpacingSize
+    SeparatorSpacingSize,
+    InviteTypes
 } from "../Constants";
 import type Member from "../structures/Member";
 import type AnnouncementChannel from "../structures/AnnouncementChannel";
@@ -838,6 +839,7 @@ export interface RawInvite {
     target_application?: RawPartialApplication;
     target_type?: InviteTargetTypes;
     target_user?: RawUser;
+    type: InviteTypes;
 }
 
 export interface RawInviteWithMetadata extends RawInvite {

--- a/lib/types/gateway-raw.d.ts
+++ b/lib/types/gateway-raw.d.ts
@@ -38,7 +38,7 @@ import type { RawScheduledEvent } from "./scheduled-events";
 import type { RawVoiceState } from "./voice";
 import type { RawInteraction } from "./interactions";
 import type { RawAuditLogEntry } from "./audit-log";
-import type { GatewayOPCodes, InviteTargetTypes, ReactionType } from "../Constants";
+import type { GatewayOPCodes, InviteTargetTypes, InviteTypes, ReactionType } from "../Constants";
 
 export type AnyReceivePacket = AnyDispatchPacket | HeartbeatPacket | ReconnectPacket | InvalidSessionPacket | HelloPacket | HeartbeatAckPacket;
 export interface RawPacket {
@@ -404,6 +404,7 @@ export interface InviteCreatePacket extends BaseDispatchPacket {
         target_type?: InviteTargetTypes;
         target_user?: RawUser;
         temporary: boolean;
+        type: InviteTypes;
         uses: number;
     };
     t: "INVITE_CREATE";


### PR DESCRIPTION
https://discord.com/developers/docs/resources/invite#invite-object
Not documented for 
https://discord.com/developers/docs/events/gateway-events#invite-create
but that is presumably just a mistake - I imagine it won't be removed from the gateway event as that would make no sense
Edit: unless the type is always the same I guess? but why would the guild_id be optional if it's only ever sent for the GUILD type