### PR TITLE
Refactor: Fix snowflake ID generation using BigInt for accurate timestamp handling

### DIFF
--- a/lib/structures/Base.ts
+++ b/lib/structures/Base.ts
@@ -3,7 +3,7 @@ import type Client from "../Client";
 import type { JSONBase } from "../types/json";
 import { inspect } from "node:util";
 
-const DISCORD_EPOCH = 1420070400000;
+const DISCORD_EPOCH = 1420070400000n;
 /** A base class which most other classes extend. */
 export default abstract class Base {
     client!: Client;
@@ -22,11 +22,12 @@ export default abstract class Base {
         if (timestamp instanceof Date) {
             timestamp = timestamp.getTime();
         }
-        return ((timestamp - DISCORD_EPOCH) << 22).toString();
+        const ms = BigInt(timestamp);
+        return ((ms - DISCORD_EPOCH) << 22n).toString();
     }
 
     static getCreatedAt(id: string): Date {
-        return new Date(Base.getDiscordEpoch(id) + DISCORD_EPOCH);
+        return new Date(Base.getDiscordEpoch(id) + Number(DISCORD_EPOCH));
     }
 
     static getDiscordEpoch(id: string): number {


### PR DESCRIPTION
Hi, the `Base.generateID` method returns incoherent results: tiny and truncated IDs that aren't representative of the input timestamp.

e.g.
```ts
Base.generateID(Date.now());
// >returns '260046848'
```

I've identified that this was due to the 32 bit limit on numbers when doing the left shift operation.
Using BigInts instead when handling these timestamps fixes the issue and avoids the truncation.

The result should now be correct:

```ts
Base.generateID();
// >returns '1364989360453189632'
```