### PR TITLE
Fix closed thread not being cached globally in Channels#get

### DIFF
--- a/lib/util/Util.ts
+++ b/lib/util/Util.ts
@@ -1,6 +1,5 @@
 /** @module Util */
 import { CDN_URL } from "./Routes";
-import type TypedCollection from "./TypedCollection";
 import type Client from "../Client";
 import {
     ButtonStyles,
@@ -43,15 +42,12 @@ import type {
     CollectionLimitsOptions,
     GuildEmoji,
     ModalSubmitComponentsActionRow,
-    RawAnnouncementThreadChannel,
     RawGroupChannel,
     RawGuildEmoji,
     RawMessage,
     RawModalSubmitComponents,
     RawModalSubmitComponentsActionRow,
     RawPrivateChannel,
-    RawPrivateThreadChannel,
-    RawPublicThreadChannel,
     RawSelectMenuComponent,
     RawStringSelectMenu,
     SelectMenuComponent,

--- a/lib/util/Util.ts
+++ b/lib/util/Util.ts
@@ -682,7 +682,7 @@ export default class Util {
                     if (!channelData.parent_id) {
                         break guild;
                     }
-                    return (guild.threads.has(channelData.id) ? guild.threads.update(channelData as never) : (guild.threads as TypedCollection<RawAnnouncementThreadChannel | RawPublicThreadChannel | RawPrivateThreadChannel, AnyThreadChannel, []>).add(Channel.from<AnyThreadChannel>(channelData, this._client))) as T;
+                    return guild.threads.update(channelData as RawThreadChannel) as T;
                 } else {
                     return guild.channels.update(channelData as RawGuildChannel) as T;
                 }


### PR DESCRIPTION
`Util#updateChannel` constructs the thread itself meaning that it doesn't set the value in `Client#threadGuildMap` (and therefore client.getChannel(id)).

I hope I did not miss anything - but I believe this only affects this function (and therefore you will probably only encounter this with closed threads or if you don't have the relevant intent (`GUILDS`?) (idk this is just embarassing)) and behaves the same except properly populating the map

https://github.com/OceanicJS/Oceanic/blob/84665ca5cf91dc16cb6a92d8276995bee716f8cb/lib/routes/Channels.ts#L576-L587

I assumed there was a specific reason for the old code, so please let me know if that's the case