### PR TITLE
Allow flags in webhook/interaction edit

### DIFF
--- a/lib/routes/Webhooks.ts
+++ b/lib/routes/Webhooks.ts
@@ -136,6 +136,7 @@ export default class Webhooks {
                 components:       options.components ? this._manager.client.util.componentsToRaw(options.components) : undefined,
                 content:          options.content,
                 embeds:           options.embeds ? this._manager.client.util.embedsToRaw(options.embeds) : undefined,
+                flags:            options.flags,
                 poll:             options.poll ? {
                     allow_multiselect: options.poll.allowMultiselect,
                     answers:           options.poll.answers.map(a => ({

--- a/lib/types/interactions.d.ts
+++ b/lib/types/interactions.d.ts
@@ -46,7 +46,7 @@ import type Permission from "../structures/Permission";
 import type ModalSubmitInteractionComponentsWrapper from "../util/interactions/ModalSubmitInteractionComponentsWrapper";
 
 export interface InteractionContent extends Pick<ExecuteWebhookOptions, "tts" | "content" | "embeds" | "allowedMentions" | "flags" | "components" | "attachments" | "files" | "poll"> {}
-export interface EditInteractionContent extends Pick<EditWebhookMessageOptions, "content" | "embeds" | "allowedMentions" | "components" | "attachments" | "files" | "poll"> {}
+export interface EditInteractionContent extends Pick<EditWebhookMessageOptions, "content" | "embeds" | "allowedMentions" | "flags" | "components" | "attachments" | "files" | "poll"> {}
 
 export type InteractionResponse = PingInteractionResponse | MessageInteractionResponse | DeferredInteractionResponse | AutocompleteInteractionResponse | ModalSubmitInteractionResponse | PremiumRequiredResponse | LaunchActivityResponse;
 export interface PingInteractionResponse {

--- a/lib/types/webhooks.d.ts
+++ b/lib/types/webhooks.d.ts
@@ -67,7 +67,7 @@ export interface GetWebhookMessageOptions {
     threadID?: string;
 }
 
-export interface EditWebhookMessageOptions extends Nullable<Pick<ExecuteWebhookOptions, "content" | "embeds" | "allowedMentions" | "components" | "attachments" | "threadID" | "files">> {
+export interface EditWebhookMessageOptions extends Nullable<Pick<ExecuteWebhookOptions, "content" | "embeds" | "allowedMentions" | "components" | "attachments" | "threadID" | "files" | "flags">> {
     /** Polls can only be added when editing a deferred interaction response. */
     poll?: MessagePollOptions;
 }


### PR DESCRIPTION
Not documented but pretty necessary for cv2 lol
Allows the following:
- Interaction defer before components v2 response
- Supressing embeds in webhook edit
- Promoting webhook to components v2