### PR TITLE
Use isDeepStrictEqual instead of comparing JSON strings

### DIFF
--- a/lib/Client.ts
+++ b/lib/Client.ts
@@ -24,6 +24,7 @@ import { DependencyError, UncachedError } from "./util/Errors";
 // @ts-ignore
 import type OAuthHelper from "./rest/OAuthHelper";
 import type { DiscordGatewayAdapterLibraryMethods, VoiceConnection } from "@discordjs/voice";
+import { isDeepStrictEqual } from "node:util";
 
 // @ts-ignore
 let DiscordJSVoice: typeof import("@discordjs/voice") | undefined;
@@ -127,7 +128,7 @@ export default class Client<E extends ClientEvents = ClientEvents> extends Typed
                 detail: "Set the disableCache option to the literal string \"no-warning\" to disable this warning."
             });
         }
-        if (disableCache && options?.collectionLimits !== undefined && JSON.stringify(options.collectionLimits) !== JSON.stringify(colZero)) {
+        if (disableCache && options?.collectionLimits !== undefined && !isDeepStrictEqual(options.collectionLimits, colZero)) {
             process.emitWarning("Providing the collectionsLimit option when the disableCache option has been enabled is redundant. Any provided values will be ignored.", {
                 code:   "OCEANIC_COLLECTIONS_LIMIT_WITH_CACHE_DISABLED",
                 detail: "Remove the collectionsLimit option, or zero out all of the possible options to disable this warning."

--- a/lib/gateway/events.ts
+++ b/lib/gateway/events.ts
@@ -35,6 +35,7 @@ import VoiceState from "../structures/VoiceState";
 import AuditLogEntry from "../structures/AuditLogEntry";
 import type User from "../structures/User";
 import Soundboard from "../structures/Soundboard";
+import { isDeepStrictEqual } from "node:util";
 
 export async function APPLICATION_COMMAND_PERMISSIONS_UPDATE(data: DispatchEventMap["APPLICATION_COMMAND_PERMISSIONS_UPDATE"], shard: Shard): Promise<void> {
     shard.client.emit("applicationCommandPermissionsUpdate", shard.client.guilds.get(data.guild_id) ?? { id: data.guild_id }, {
@@ -696,7 +697,7 @@ export async function PRESENCE_UPDATE(data: DispatchEventMap["PRESENCE_UPDATE"],
     if (user) {
         const oldUser = user.toJSON();
         user["update"](data.user);
-        if (JSON.stringify(oldUser) !== JSON.stringify(user.toJSON())) {
+        if (!isDeepStrictEqual(oldUser, user.toJSON())) {
             shard.client.emit("userUpdate", user, oldUser);
         }
     }
@@ -981,7 +982,7 @@ export async function VOICE_STATE_UPDATE(data: DispatchEventMap["VOICE_STATE_UPD
         }
     }
 
-    if (JSON.stringify(oldState) !== JSON.stringify(state.toJSON())) {
+    if (!isDeepStrictEqual(oldState, state.toJSON())) {
         shard.client.emit("voiceStateUpdate", member, oldState);
     }
 }


### PR DESCRIPTION
Take this with a grain of salt, but `isDeepStrictEqual` is seemingly faster most of the time (sometimes with big arrays/objects it seems to somehow be slower with identical values).
Considering it's been around since Node v9.0.0 there's probably not much reason not to use it.
Given valid JSON objects, the only catch should be that 0 and -0 are considered different. The benefit in behaviour is that key order is ignored.