### PR TITLE
Add String Select and Label components to modals

### DIFF
--- a/lib/Constants.ts
+++ b/lib/Constants.ts
@@ -815,6 +815,7 @@ export enum ComponentTypes {
 
     CONTENT_INVENTORY_ENTRY = 16,
     CONTAINER               = 17,
+    LABEL                   = 18,
 }
 
 export type SelectMenuNonResolvedTypes = ComponentTypes.STRING_SELECT;
@@ -822,7 +823,7 @@ export type SelectMenuResolvedTypes = ComponentTypes.USER_SELECT | ComponentType
 export type SelectMenuTypes = SelectMenuNonResolvedTypes | SelectMenuResolvedTypes;
 
 export type MessageComponentTypes = ComponentTypes.BUTTON | SelectMenuTypes;
-export type ModalComponentTypes = ComponentTypes.TEXT_INPUT;
+export type ModalComponentTypes = ComponentTypes.TEXT_INPUT | ComponentTypes.STRING_SELECT;
 
 export enum ButtonStyles {
     PRIMARY   = 1,

--- a/lib/types/channels.d.ts
+++ b/lib/types/channels.d.ts
@@ -1219,11 +1219,13 @@ export interface RawSectionComponent extends BaseComponent {
 
 export type RawComponent = AnyRawMessageComponent | AnyRawModalComponent;
 export type AnyRawMessageComponent = RawMessageComponent | RawMessageActionRowComponent | RawThumbnailComponent;
-export type AnyRawModalComponent = RawModalComponent | RawModalActionRowComponent;
+export type AnyRawModalComponent = RawModalComponent | RawModalActionRowComponent | RawModalLabelComponent;
 export type RawMessageActionRowComponent = RawButtonComponent | RawSelectMenuComponent;
 export type RawMessageComponent = RawMessageActionRow | RawSectionComponent | RawTextDisplayComponent | RawMediaGalleryComponent | RawSeparatorComponent | RawFileComponent | RawContainerComponent;
+/** @deprecated */
 export type RawModalActionRowComponent = RawTextInput;
-export type RawModalComponent = RawModalActionRow;
+export type RawModalLabelComponent = RawStringSelectMenu | RawTextInput;
+export type RawModalComponent = RawModalActionRow | RawModalLabel;
 export type RawButtonComponent = RawTextButton | URLButton | RawPremiumButton;
 export type RawSelectMenuComponent = RawStringSelectMenu | RawUserSelectMenu | RawRoleSelectMenu | RawMentionableSelectMenu | RawChannelSelectMenu;
 
@@ -1245,7 +1247,8 @@ export type ToComponentFromRaw<T extends RawComponent> =
                                                             T extends RawSeparatorComponent ? SeparatorComponent :
                                                                 T extends RawFileComponent ? FileComponent :
                                                                     T extends RawContainerComponent ? ContainerComponent :
-                                                                        never;
+                                                                        T extends RawModalLabel ? ModalLabel :
+                                                                            never;
 export type ToRawFromComponent<T extends Component> =
     T extends MessageActionRow ? RawMessageActionRow :
         T extends ModalActionRow ? RawModalActionRow :
@@ -1264,7 +1267,8 @@ export type ToRawFromComponent<T extends Component> =
                                                             T extends SeparatorComponent ? RawSeparatorComponent :
                                                                 T extends FileComponent ? RawFileComponent :
                                                                     T extends ContainerComponent ? RawContainerComponent :
-                                                                        never;
+                                                                        T extends ModalLabel ? RawModalLabel :
+                                                                            never;
 
 export interface RawActionRowBase<T extends RawComponent> {
     components: Array<T>;
@@ -1272,6 +1276,7 @@ export interface RawActionRowBase<T extends RawComponent> {
 }
 
 export interface RawMessageActionRow extends RawActionRowBase<RawMessageActionRowComponent> {}
+/** @deprecated */
 export interface RawModalActionRow extends RawActionRowBase<RawModalActionRowComponent> {}
 export type ActionRowToRaw<T extends MessageActionRow | ModalActionRow> =
     T extends MessageActionRow ? RawMessageActionRow :
@@ -1279,11 +1284,13 @@ export type ActionRowToRaw<T extends MessageActionRow | ModalActionRow> =
 
 export type Component = AnyMessageComponent | AnyModalComponent;
 export type AnyMessageComponent = MessageComponent | MessageActionRowComponent | ThumbnailComponent;
-export type AnyModalComponent = ModalComponent | ModalActionRowComponent;
+export type AnyModalComponent = ModalComponent | ModalActionRowComponent | ModalLabelComponent;
 export type MessageActionRowComponent = ButtonComponent | SelectMenuComponent;
 export type MessageComponent = MessageActionRow | SectionComponent | TextDisplayComponent | MediaGalleryComponent | SeparatorComponent | FileComponent | ContainerComponent;
+/** @deprecated */
 export type ModalActionRowComponent = TextInput;
-export type ModalComponent = ModalActionRow;
+export type ModalLabelComponent = StringSelectMenu | TextInput;
+export type ModalComponent = ModalActionRow | ModalLabel;
 export type ButtonComponent = TextButton | URLButton | PremiumButton;
 export type SelectMenuComponent = StringSelectMenu | UserSelectMenu | RoleSelectMenu | MentionableSelectMenu | ChannelSelectMenu;
 
@@ -1299,6 +1306,7 @@ export interface ActionRowBase<T extends Component> extends BaseComponent {
 }
 
 export interface MessageActionRow extends ActionRowBase<MessageActionRowComponent> {}
+/** @deprecated */
 export interface ModalActionRow extends ActionRowBase<ModalActionRowComponent> {}
 
 export interface ButtonBase extends BaseComponent {
@@ -1345,6 +1353,7 @@ export interface RawSelectMenuBase<T extends SelectMenuTypes> {
 
 export interface RawStringSelectMenuOptions {
     options: Array<SelectOption>;
+    required?: boolean;
 }
 
 export interface RawChannelSelectMenuOptions {
@@ -1377,6 +1386,7 @@ interface DefaultValues {
 
 export interface StringSelectMenuOptions {
     options: Array<SelectOption>;
+    required?: boolean;
 }
 
 export interface ChannelSelectMenuOptions {
@@ -1399,7 +1409,8 @@ export interface SelectOption {
 
 export interface RawTextInput {
     custom_id: string;
-    label: string;
+    /** @deprecated */
+    label?: string;
     max_length?: number;
     min_length?: number;
     placeholder?: string;
@@ -1411,7 +1422,8 @@ export interface RawTextInput {
 
 export interface TextInput extends BaseComponent {
     customID: string;
-    label: string;
+    /** @deprecated */
+    label?: string;
     maxLength?: number;
     minLength?: number;
     placeholder?: string;
@@ -1479,4 +1491,18 @@ export interface RawContainerComponent extends Omit<BaseComponent, "id"> {
     components: Array<RawMessageActionRow | RawTextDisplayComponent | RawSectionComponent | RawMediaGalleryComponent | RawSeparatorComponent | RawFileComponent>;
     spoiler?: boolean;
     type: ComponentTypes.CONTAINER;
+}
+
+export interface ModalLabel extends BaseComponent {
+    component: StringSelectMenu | TextInput;
+    description?: string;
+    label: string;
+    type: ComponentTypes.LABEL;
+}
+
+export interface RawModalLabel extends Omit<BaseComponent, "id"> {
+    component: RawStringSelectMenu | RawTextInput;
+    description?: string;
+    label: string;
+    type: ComponentTypes.LABEL;
 }

--- a/lib/types/interactions.d.ts
+++ b/lib/types/interactions.d.ts
@@ -342,23 +342,44 @@ export interface RawModalSubmitComponentsStringValue<T extends ModalComponentTyp
     value: string;
 }
 
+export interface RawModalSubmitComponentsStringValues<T extends ModalComponentTypes = ModalComponentTypes> extends RawModalSubmitComponentsBase {
+    type: T;
+    values: Array<string>;
+}
+
+/** @deprecated */
 interface RawModalComponentsActionRow<T extends RawModalSubmitComponents> {
     components: Array<T>;
     type: ComponentTypes.ACTION_ROW;
 }
 
+/** @deprecated */
 interface ModalComponentsActionRow<T extends ModalSubmitComponents> {
     components: Array<T>;
     type: ComponentTypes.ACTION_ROW;
 }
 
+interface RawModalComponentsLabel<T extends RawModalSubmitComponents> {
+    component: T;
+    type: ComponentTypes.LABEL;
+}
+
+interface ModalComponentsLabel<T extends ModalSubmitComponents> {
+    component: T;
+    type: ComponentTypes.LABEL;
+}
+
 export type ToModalSubmitComponentFromRaw<T extends RawModalSubmitComponents> =
 T extends RawModalSubmitTextInputComponent ? ModalSubmitTextInputComponent :
-    never;
+    T extends RawModalSubmitStringSelectComponent ? ModalSubmitStringSelectComponent :
+        never;
 
+/** @deprecated */
 export type RawModalSubmitComponentsActionRow = RawModalComponentsActionRow<RawModalSubmitComponents>;
-export type RawModalSubmitComponents = RawModalSubmitTextInputComponent;
+export type RawModalSubmitComponentsLabel = RawModalComponentsLabel<RawModalSubmitComponents>;
+export type RawModalSubmitComponents = RawModalSubmitTextInputComponent | RawModalSubmitStringSelectComponent;
 export interface RawModalSubmitTextInputComponent extends RawModalSubmitComponentsStringValue<ComponentTypes.TEXT_INPUT> {}
+export interface RawModalSubmitStringSelectComponent extends RawModalSubmitComponentsStringValues<ComponentTypes.STRING_SELECT> {}
 
 interface ModalSubmitComponentsBase {
     customID: string;
@@ -369,13 +390,22 @@ export interface ModalSubmitComponentsStringValue<T extends ModalComponentTypes 
     value: string;
 }
 
+export interface ModalSubmitComponentsStringValues<T extends ModalComponentTypes = ModalComponentTypes> extends ModalSubmitComponentsBase {
+    type: T;
+    value: Array<string>;
+}
+
 export type ToRawFromoModalSubmitComponent<T extends ModalSubmitComponents> =
 T extends ModalSubmitTextInputComponent ? RawModalSubmitTextInputComponent :
-    never;
+    T extends ModalSubmitStringSelectComponent ? RawModalSubmitStringSelectComponent :
+        never;
 
+/** @deprecated */
 export type ModalSubmitComponentsActionRow = ModalComponentsActionRow<ModalSubmitComponents>;
-export type ModalSubmitComponents = ModalSubmitTextInputComponent;
+export type ModalSubmitComponentsLabel = ModalComponentsLabel<ModalSubmitComponents>;
+export type ModalSubmitComponents = ModalSubmitTextInputComponent | ModalSubmitStringSelectComponent;
 export interface ModalSubmitTextInputComponent extends ModalSubmitComponentsStringValue<ComponentTypes.TEXT_INPUT> {}
+export interface ModalSubmitStringSelectComponent extends ModalSubmitComponentsStringValues<ComponentTypes.STRING_SELECT> {}
 
 export type ApplicationCommandTypesWithTarget = ApplicationCommandTypes.USER | ApplicationCommandTypes.MESSAGE;
 

--- a/lib/util/Util.ts
+++ b/lib/util/Util.ts
@@ -22,14 +22,12 @@ import type {
     Component,
     Embed,
     EmbedOptions,
-    ModalActionRow,
     RawAllowedMentions,
     RawChannel,
     RawComponent,
     RawEmbed,
     RawEmbedOptions,
     RawGuildChannel,
-    RawModalActionRow,
     RawThreadChannel,
     ToComponentFromRaw,
     ToRawFromComponent
@@ -63,7 +61,9 @@ import type {
     MessageComponent,
     ModalComponent,
     RawMessageComponent,
-    RawModalComponent
+    RawModalComponent,
+    RawModalSubmitComponentsLabel,
+    ModalSubmitComponentsLabel
 } from "../types";
 import Message from "../structures/Message";
 import Entitlement from "../structures/Entitlement";
@@ -93,9 +93,9 @@ export default class Util {
         return Array.isArray(components) ? data : data[0];
     }
 
-    static rawModalComponents(components: RawModalActionRow): ModalActionRow;
-    static rawModalComponents(components: Array<RawModalActionRow>): Array<ModalActionRow>;
-    static rawModalComponents(components: RawModalActionRow | Array<RawModalActionRow>): ModalActionRow | Array<ModalActionRow> {
+    static rawModalComponents(components: RawModalComponent): ModalComponent;
+    static rawModalComponents(components: Array<RawModalComponent>): Array<ModalComponent>;
+    static rawModalComponents(components: RawModalComponent | Array<RawModalComponent>): ModalComponent | Array<ModalComponent> {
         const data = Util.prototype.componentsToParsed(Array.isArray(components) ? components : [components]);
         return Array.isArray(components) ? data : data[0];
     }
@@ -260,6 +260,15 @@ export default class Util {
                     components: component.components.map(c => this.componentToParsed(c))
                 } as never;
             }
+
+            case ComponentTypes.LABEL: {
+                return {
+                    type:        component.type,
+                    label:       component.label,
+                    description: component.description,
+                    component:   this.componentToParsed(component.component)
+                } as never;
+            }
             default: {
                 return component as never;
             }
@@ -358,6 +367,15 @@ export default class Util {
                     type:       component.type,
                     accessory:  component.accessory ? this.componentToRaw(component.accessory) : undefined,
                     components: component.components.map(c => this.componentToRaw(c))
+                } as never;
+            }
+
+            case ComponentTypes.LABEL: {
+                return {
+                    type:        component.type,
+                    label:       component.label,
+                    description: component.description,
+                    component:   this.componentToRaw(component.component)
                 } as never;
             }
             default: {
@@ -612,17 +630,33 @@ export default class Util {
                     value:    component.value
                 } as never;
             }
+            case ComponentTypes.STRING_SELECT: {
+                return {
+                    customID: component.custom_id,
+                    type:     component.type,
+                    values:   component.values
+                } as never;
+            }
             default: {
                 return component as never;
             }
         }
     }
 
-    modalSubmitComponentsToParsed<T extends RawModalSubmitComponentsActionRow>(components: Array<T>): Array<ModalSubmitComponentsActionRow> {
-        return components.map(row => ({
-            type:       row.type,
-            components: row.components.map(component => this.modalSubmitComponentToParsed(component))
-        })) as never;
+    modalSubmitComponentsToParsed<T extends RawModalSubmitComponentsActionRow | RawModalSubmitComponentsLabel>(components: Array<T>): Array<ModalSubmitComponentsActionRow | ModalSubmitComponentsLabel> {
+        return components.map(row => {
+            if (row.type === ComponentTypes.ACTION_ROW) {
+                return {
+                    type:       row.type,
+                    components: row.components ? row.components.map(component => this.modalSubmitComponentToParsed(component)) : undefined
+                };
+            } else {
+                return {
+                    type:      row.type,
+                    component: row.component ? this.modalSubmitComponentToParsed(row.component) : undefined
+                };
+            }
+        }) as never;
     }
 
     optionToParsed(option: RawApplicationCommandOption): ApplicationCommandOptions {

--- a/lib/util/Util.ts
+++ b/lib/util/Util.ts
@@ -337,7 +337,7 @@ export default class Util {
                 }
 
                 if (component.type === ComponentTypes.STRING_SELECT) {
-                    return { ...rawComponent, options: component.options } as never;
+                    return { ...rawComponent, options: component.options, required: component.required } as never;
                 } else if (component.type === ComponentTypes.CHANNEL_SELECT) {
                     return { ...rawComponent, channel_types: component.channelTypes } as never;
                 } else {

--- a/lib/util/interactions/ModalSubmitInteractionComponentsWrapper.ts
+++ b/lib/util/interactions/ModalSubmitInteractionComponentsWrapper.ts
@@ -1,13 +1,13 @@
 /** @module ModalSubmitInteractionComponentsWrapper */
 import { WrapperError } from "../Errors";
 import { ComponentTypes, type ModalComponentTypes } from "../../Constants";
-import type { ModalSubmitComponents, ModalSubmitComponentsActionRow, ModalSubmitTextInputComponent } from "../../types/interactions";
+import type { ModalSubmitComponents, ModalSubmitComponentsActionRow, ModalSubmitComponentsLabel, ModalSubmitTextInputComponent } from "../../types/interactions";
 
 /** A wrapper for interaction components. */
 export default class ModalSubmitInteractionComponentsWrapper {
     /** The raw components from Discord.  */
-    raw: Array<ModalSubmitComponentsActionRow>;
-    constructor(data: Array<ModalSubmitComponentsActionRow>) {
+    raw: Array<ModalSubmitComponentsActionRow | ModalSubmitComponentsLabel>;
+    constructor(data: Array<ModalSubmitComponentsActionRow | ModalSubmitComponentsLabel>) {
         this.raw = data;
     }
 
@@ -22,7 +22,7 @@ export default class ModalSubmitInteractionComponentsWrapper {
 
     /** Get the components in this interaction. */
     getComponents(): Array<ModalSubmitComponents> {
-        return this.raw.reduce((a, b) => a.concat(...b.components), [] as Array<ModalSubmitComponents>);
+        return this.raw.reduce((a, b) => a.concat(...(b.type === ComponentTypes.ACTION_ROW ? b.components : [b.component])), [] as Array<ModalSubmitComponents>);
     }
 
     /**


### PR DESCRIPTION
This also deprecates ActionRows in modals and deprecates/makes optional the `label` field in text inputs. This adheres to the upcoming Phase 1 components rollout, which should happen within the next few days.

(This has been tested, but the features in question haven't been rolled out to the public just yet; attempts to use the new components/fields in modals in most environments will most likely fail with an Invalid Form Body error!)

<img width="493" height="346" alt="image" src="https://github.com/user-attachments/assets/793b825e-7b01-433b-b403-4238838eab66" />
