### PR TITLE
Add text displays and all other Select Menu types to modals

### DIFF
--- a/examples/interactions.js
+++ b/examples/interactions.js
@@ -152,7 +152,7 @@ client.on("interactionCreate", async(interaction) => {
             switch(interaction.data.customID) {
                 case "test-modal": {
                     // the `components` property under data contains all the components that were submitted
-                    // https://docs.oceanic.ws/latest/interfaces/Types_Channels.ModalActionRow.html
+                    // https://docs.oceanic.ws/latest/interfaces/Types_Channels.ModalComponent.html
                     console.log(interaction.data.components);
                     break;
                 }

--- a/examples/modals.js
+++ b/examples/modals.js
@@ -1,0 +1,116 @@
+const { Client, ComponentTypes, ApplicationCommandTypes, InteractionTypes, ChannelTypes } = require("oceanic.js");
+
+const client = new Client({
+    auth: "Bot [TOKEN]",
+    gateway: {
+        intents: [] // modals need no intents
+    }
+});
+
+const GUILD_ID = "";
+client.on("ready", async () => {
+    console.log("Ready as", client.user.tag);
+
+    await client.application.bulkEditGuildCommands(GUILD_ID, [
+        {
+            type: ApplicationCommandTypes.CHAT_INPUT,
+            name: "test",
+            description: "Test"
+        }
+    ]);
+});
+
+client.on("interactionCreate", async (interaction) => {
+    switch (interaction.type) {
+        // https://docs.oceanic.ws/latest/classes/CommandInteraction.html
+        case InteractionTypes.APPLICATION_COMMAND: {
+            if (interaction.data.name === "test") {
+                // Modals are an initial response, so we cannot defer before creating one
+                await interaction.createModal({
+                    customID: "modal",
+                    title: "Example Modal",
+                    components: [
+                        {
+                            // Only labels and text displays can be used as top-level modal components.
+                            // Full list of types: https://docs.oceanic.ws/latest/enums/Constants.ComponentTypes.html
+                            // https://docs.oceanic.ws/latest/interfaces/Types_Channels.ModalLabel.html
+                            type: ComponentTypes.LABEL,
+                            label: "Label 1",
+                            description: "Label description",
+                            component: {
+                                // https://docs.oceanic.ws/latest/interfaces/Types_Channels.SelectMenu.html
+                                type: ComponentTypes.STRING_SELECT,
+                                customID: "string-select",
+                                required: true,
+                                maxValues: 1, // The maximum number of values that can be selected (default 1)
+                                minValues: 1, // The minimum number of values that can be selected (default 1)
+                                options: [
+                                    // https://docs.oceanic.ws/latest/interfaces/Types_Channels.SelectOption.html
+                                    {
+                                        default: true, // If this option is selected by default
+                                        description: "The description of the option", // Optional description
+                                        emoji: { // An optional emoji
+                                            id: "1013346070606123009",
+                                            name: "oceanic"
+                                        },
+                                        label: "Option One",
+                                        value: "value-1"
+                                    },
+                                    {
+                                        label: "Option Two",
+                                        value: "option-2"
+                                    }
+                                ],
+                                placeholder: "Some Placeholder Text"
+                            }
+                        },
+                        {
+                            // https://docs.oceanic.ws/latest/interfaces/Types_Channels.TextDisplayComponent.html
+                            type: ComponentTypes.TEXT_DISPLAY,
+                            content: "Example Text Display"
+                        },
+                        {
+                            // https://docs.oceanic.ws/latest/interfaces/Types_Channels.ModalLabel.html
+                            type: ComponentTypes.LABEL,
+                            label: "Label 2",
+                            description: "Another label description",
+                            component: {
+                                // https://docs.oceanic.ws/latest/interfaces/Types_Channels.SelectMenu.html
+                                type: ComponentTypes.CHANNEL_SELECT,
+                                channelTypes: [ChannelTypes.GUILD_TEXT, ChannelTypes.GUILD_VOICE], // The types of channels that can be selected
+                                customID: "channel-select",
+                                required: false,
+                                maxValues: 1, // The maximum number of values that can be selected (default 1)
+                                minValues: 1, // The minimum number of values that can be selected (default 1)
+                                placeholder: "Some Placeholder Text"
+                            }
+                        }
+                    ]
+                });
+            }
+            break;
+        }
+
+        // https://docs.oceanic.ws/latest/classes/ModalSubmitInteraction.html
+        case InteractionTypes.MODAL_SUBMIT: {
+            // this will correspond with the customID you provided when creating the modal
+            switch(interaction.data.customID) {
+                case "test-modal": {
+                    // the `components` property under data contains all the components that were submitted
+                    // https://docs.oceanic.ws/latest/interfaces/Types_Channels.ModalComponent.html
+                    console.log(interaction.data.components);
+                    break;
+                }
+            }
+            break;
+        }
+    }
+});
+
+// An error handler
+client.on("error", (error) => {
+    console.error("Something went wrong:", error);
+});
+
+// Connect to Discord
+client.connect();

--- a/lib/Constants.ts
+++ b/lib/Constants.ts
@@ -823,7 +823,7 @@ export type SelectMenuResolvedTypes = ComponentTypes.USER_SELECT | ComponentType
 export type SelectMenuTypes = SelectMenuNonResolvedTypes | SelectMenuResolvedTypes;
 
 export type MessageComponentTypes = ComponentTypes.BUTTON | SelectMenuTypes;
-export type ModalComponentTypes = ComponentTypes.TEXT_INPUT | ComponentTypes.STRING_SELECT;
+export type ModalComponentTypes = ComponentTypes.TEXT_INPUT | SelectMenuTypes;
 
 export enum ButtonStyles {
     PRIMARY   = 1,

--- a/lib/structures/ModalSubmitInteraction.ts
+++ b/lib/structures/ModalSubmitInteraction.ts
@@ -1,7 +1,7 @@
 /** @module ModalSubmitInteraction */
 import Interaction from "./Interaction";
-import type Member from "./Member";
-import type User from "./User";
+import Member from "./Member";
+import User from "./User";
 import type Guild from "./Guild";
 import Permission from "./Permission";
 import Message from "./Message";
@@ -9,6 +9,8 @@ import GuildChannel from "./GuildChannel";
 import type PrivateChannel from "./PrivateChannel";
 import type Entitlement from "./Entitlement";
 import type TestEntitlement from "./TestEntitlement";
+import InteractionResolvedChannel from "./InteractionResolvedChannel";
+import Role from "./Role";
 import { InteractionResponseTypes, type InteractionTypes, type InteractionContextTypes } from "../Constants";
 import type {
     AuthorizingIntegrationOwners,
@@ -17,15 +19,19 @@ import type {
     InteractionContent,
     InteractionGuild,
     ModalSubmitInteractionData,
+    ModalSubmitInteractionResolvedData,
     RawModalSubmitInteraction
 } from "../types/interactions";
 import type Client from "../Client";
 import type { AnyTextableGuildChannel, AnyInteractionChannel } from "../types/channels";
 import type { JSONModalSubmitInteraction } from "../types/json";
 import type { Uncached } from "../types/shared";
+import TypedCollection from "../util/TypedCollection";
 import { UncachedError } from "../util/Errors";
 import MessageInteractionResponse, { type FollowupMessageInteractionResponse, type InitialMessagedInteractionResponse } from "../util/interactions/MessageInteractionResponse";
 import ModalSubmitInteractionComponentsWrapper from "../util/interactions/ModalSubmitInteractionComponentsWrapper";
+import type { RawMember } from "../types/guilds";
+import type { RawUser } from "../types/users";
 
 /** Represents a modal submit interaction. */
 export default class ModalSubmitInteraction<T extends AnyInteractionChannel | Uncached = AnyInteractionChannel | Uncached> extends Interaction {
@@ -73,10 +79,6 @@ export default class ModalSubmitInteraction<T extends AnyInteractionChannel | Un
         this.authorizingIntegrationOwners = data.authorizing_integration_owners;
         this.channelID = data.channel_id!;
         this.context = data.context;
-        this.data = {
-            components: new ModalSubmitInteractionComponentsWrapper(client.util.modalSubmitComponentsToParsed(data.data.components)),
-            customID:   data.data.custom_id
-        };
         this.entitlements = data.entitlements?.map(entitlement => client.util.updateEntitlement(entitlement)) ?? [];
         this.guildID = (data.guild_id ?? null) as T extends AnyTextableGuildChannel ? string : string | null;
         this.guildLocale = data.guild_locale as T extends AnyTextableGuildChannel ? string : string | undefined;
@@ -88,6 +90,47 @@ export default class ModalSubmitInteraction<T extends AnyInteractionChannel | Un
             this.message = (this.channel && "messages" in this.channel && (this.channel.messages.update(data.message) as Message<T>)) || new Message<T>(data.message, client);
         }
         this.user = client.users.update(data.user ?? data.member!.user);
+
+        const resolved: ModalSubmitInteractionResolvedData = {
+            channels: new TypedCollection(InteractionResolvedChannel, client),
+            members:  new TypedCollection(Member, client),
+            roles:    new TypedCollection(Role, client),
+            users:    new TypedCollection(User, client)
+        };
+
+        if (data.data.resolved) {
+            if (data.data.resolved.channels) {
+                for (const channel of Object.values(data.data.resolved.channels)) resolved.channels.update(channel);
+            }
+
+            if (data.data.resolved.members) {
+                for (const [id, member] of Object.entries(data.data.resolved.members)) {
+                    const m = member as unknown as RawMember & { user: RawUser; };
+                    m.user = data.data.resolved.users![id];
+                    resolved.members.add(client.util.updateMember(data.guild_id!, id, m));
+                }
+            }
+
+            if (data.data.resolved.roles) {
+                for (const role of Object.values(data.data.resolved.roles)) {
+                    try {
+                        resolved.roles.add(this.guild?.roles.update(role, this.guildID!) ?? new Role(role, client, this.guildID!));
+                    } catch {
+                        resolved.roles.add(new Role(role, client, this.guildID!));
+                    }
+                }
+            }
+
+            if (data.data.resolved.users) {
+                for (const user of Object.values(data.data.resolved.users)) resolved.users.add(client.users.update(user));
+            }
+        }
+
+        this.data = {
+            components: new ModalSubmitInteractionComponentsWrapper(client.util.modalSubmitComponentsToParsed(data.data.components)),
+            customID:   data.data.custom_id,
+            resolved
+        };
     }
 
     /** The channel this interaction was sent from. */

--- a/lib/types/channels.d.ts
+++ b/lib/types/channels.d.ts
@@ -1220,12 +1220,13 @@ export interface RawSectionComponent extends BaseComponent {
 export type RawComponent = AnyRawMessageComponent | AnyRawModalComponent;
 export type AnyRawMessageComponent = RawMessageComponent | RawMessageActionRowComponent | RawThumbnailComponent;
 export type AnyRawModalComponent = RawModalComponent | RawModalActionRowComponent | RawModalLabelComponent;
+export type AnyRawBaseComponent = RawMessageComponent | RawModalComponent;
 export type RawMessageActionRowComponent = RawButtonComponent | RawSelectMenuComponent;
 export type RawMessageComponent = RawMessageActionRow | RawSectionComponent | RawTextDisplayComponent | RawMediaGalleryComponent | RawSeparatorComponent | RawFileComponent | RawContainerComponent;
 /** @deprecated */
 export type RawModalActionRowComponent = RawTextInput;
-export type RawModalLabelComponent = RawStringSelectMenu | RawTextInput;
-export type RawModalComponent = RawModalActionRow | RawModalLabel;
+export type RawModalLabelComponent = RawSelectMenuComponent | RawTextInput;
+export type RawModalComponent = RawModalActionRow | RawModalLabel | RawTextDisplayComponent;
 export type RawButtonComponent = RawTextButton | URLButton | RawPremiumButton;
 export type RawSelectMenuComponent = RawStringSelectMenu | RawUserSelectMenu | RawRoleSelectMenu | RawMentionableSelectMenu | RawChannelSelectMenu;
 
@@ -1285,12 +1286,13 @@ export type ActionRowToRaw<T extends MessageActionRow | ModalActionRow> =
 export type Component = AnyMessageComponent | AnyModalComponent;
 export type AnyMessageComponent = MessageComponent | MessageActionRowComponent | ThumbnailComponent;
 export type AnyModalComponent = ModalComponent | ModalActionRowComponent | ModalLabelComponent;
+export type AnyBaseComponent = MessageComponent | ModalComponent;
 export type MessageActionRowComponent = ButtonComponent | SelectMenuComponent;
 export type MessageComponent = MessageActionRow | SectionComponent | TextDisplayComponent | MediaGalleryComponent | SeparatorComponent | FileComponent | ContainerComponent;
 /** @deprecated */
 export type ModalActionRowComponent = TextInput;
-export type ModalLabelComponent = StringSelectMenu | TextInput;
-export type ModalComponent = ModalActionRow | ModalLabel;
+export type ModalLabelComponent = SelectMenuComponent | TextInput;
+export type ModalComponent = ModalActionRow | ModalLabel | TextDisplayComponent;
 export type ButtonComponent = TextButton | URLButton | PremiumButton;
 export type SelectMenuComponent = StringSelectMenu | UserSelectMenu | RoleSelectMenu | MentionableSelectMenu | ChannelSelectMenu;
 
@@ -1348,12 +1350,12 @@ export interface RawSelectMenuBase<T extends SelectMenuTypes> {
     max_values?: number;
     min_values?: number;
     placeholder?: string;
+    required?: boolean;
     type: T;
 }
 
 export interface RawStringSelectMenuOptions {
     options: Array<SelectOption>;
-    required?: boolean;
 }
 
 export interface RawChannelSelectMenuOptions {
@@ -1373,6 +1375,7 @@ export interface SelectMenuBase<T extends SelectMenuTypes> extends BaseComponent
     maxValues?: number;
     minValues?: number;
     placeholder?: string;
+    required?: boolean;
     type: T;
 }
 
@@ -1386,7 +1389,6 @@ interface DefaultValues {
 
 export interface StringSelectMenuOptions {
     options: Array<SelectOption>;
-    required?: boolean;
 }
 
 export interface ChannelSelectMenuOptions {
@@ -1494,14 +1496,14 @@ export interface RawContainerComponent extends Omit<BaseComponent, "id"> {
 }
 
 export interface ModalLabel extends BaseComponent {
-    component: StringSelectMenu | TextInput;
+    component: SelectMenuComponent | TextInput;
     description?: string;
     label: string;
     type: ComponentTypes.LABEL;
 }
 
 export interface RawModalLabel extends Omit<BaseComponent, "id"> {
-    component: RawStringSelectMenu | RawTextInput;
+    component: RawSelectMenuComponent | RawTextInput;
     description?: string;
     label: string;
     type: ComponentTypes.LABEL;

--- a/lib/types/interactions.d.ts
+++ b/lib/types/interactions.d.ts
@@ -372,14 +372,23 @@ interface ModalComponentsLabel<T extends ModalSubmitComponents> {
 export type ToModalSubmitComponentFromRaw<T extends RawModalSubmitComponents> =
 T extends RawModalSubmitTextInputComponent ? ModalSubmitTextInputComponent :
     T extends RawModalSubmitStringSelectComponent ? ModalSubmitStringSelectComponent :
-        never;
+        T extends RawModalSubmitUserSelectComponent ? ModalSubmitUserSelectComponent :
+            T extends RawModalSubmitRoleSelectComponent ? ModalSubmitRoleSelectComponent :
+                T extends RawModalSubmitMentionableSelectComponent ? ModalSubmitMentionableSelectComponent :
+                    T extends RawModalSubmitChannelSelectComponent ? ModalSubmitChannelSelectComponent :
+                        never;
 
 /** @deprecated */
 export type RawModalSubmitComponentsActionRow = RawModalComponentsActionRow<RawModalSubmitComponents>;
 export type RawModalSubmitComponentsLabel = RawModalComponentsLabel<RawModalSubmitComponents>;
-export type RawModalSubmitComponents = RawModalSubmitTextInputComponent | RawModalSubmitStringSelectComponent;
+export type RawModalSubmitComponents = RawModalSubmitTextInputComponent | RawModalSubmitSelectComponents;
+export type RawModalSubmitSelectComponents = RawModalSubmitStringSelectComponent | RawModalSubmitUserSelectComponent | RawModalSubmitRoleSelectComponent | RawModalSubmitMentionableSelectComponent | RawModalSubmitChannelSelectComponent;
 export interface RawModalSubmitTextInputComponent extends RawModalSubmitComponentsStringValue<ComponentTypes.TEXT_INPUT> {}
 export interface RawModalSubmitStringSelectComponent extends RawModalSubmitComponentsStringValues<ComponentTypes.STRING_SELECT> {}
+export interface RawModalSubmitUserSelectComponent extends RawModalSubmitComponentsStringValues<ComponentTypes.USER_SELECT> {}
+export interface RawModalSubmitRoleSelectComponent extends RawModalSubmitComponentsStringValues<ComponentTypes.ROLE_SELECT> {}
+export interface RawModalSubmitMentionableSelectComponent extends RawModalSubmitComponentsStringValues<ComponentTypes.MENTIONABLE_SELECT> {}
+export interface RawModalSubmitChannelSelectComponent extends RawModalSubmitComponentsStringValues<ComponentTypes.CHANNEL_SELECT> {}
 
 interface ModalSubmitComponentsBase {
     customID: string;
@@ -398,14 +407,23 @@ export interface ModalSubmitComponentsStringValues<T extends ModalComponentTypes
 export type ToRawFromoModalSubmitComponent<T extends ModalSubmitComponents> =
 T extends ModalSubmitTextInputComponent ? RawModalSubmitTextInputComponent :
     T extends ModalSubmitStringSelectComponent ? RawModalSubmitStringSelectComponent :
-        never;
+        T extends ModalSubmitUserSelectComponent ? RawModalSubmitUserSelectComponent :
+            T extends ModalSubmitRoleSelectComponent ? RawModalSubmitRoleSelectComponent :
+                T extends ModalSubmitMentionableSelectComponent ? RawModalSubmitMentionableSelectComponent :
+                    T extends ModalSubmitChannelSelectComponent ? RawModalSubmitChannelSelectComponent :
+                        never;
 
 /** @deprecated */
 export type ModalSubmitComponentsActionRow = ModalComponentsActionRow<ModalSubmitComponents>;
 export type ModalSubmitComponentsLabel = ModalComponentsLabel<ModalSubmitComponents>;
-export type ModalSubmitComponents = ModalSubmitTextInputComponent | ModalSubmitStringSelectComponent;
+export type ModalSubmitComponents = ModalSubmitTextInputComponent | ModalSubmitSelectComponents;
+export type ModalSubmitSelectComponents = ModalSubmitStringSelectComponent | ModalSubmitUserSelectComponent | ModalSubmitRoleSelectComponent | ModalSubmitMentionableSelectComponent | ModalSubmitChannelSelectComponent;
 export interface ModalSubmitTextInputComponent extends ModalSubmitComponentsStringValue<ComponentTypes.TEXT_INPUT> {}
 export interface ModalSubmitStringSelectComponent extends ModalSubmitComponentsStringValues<ComponentTypes.STRING_SELECT> {}
+export interface ModalSubmitUserSelectComponent extends ModalSubmitComponentsStringValues<ComponentTypes.USER_SELECT> {}
+export interface ModalSubmitRoleSelectComponent extends ModalSubmitComponentsStringValues<ComponentTypes.ROLE_SELECT> {}
+export interface ModalSubmitMentionableSelectComponent extends ModalSubmitComponentsStringValues<ComponentTypes.MENTIONABLE_SELECT> {}
+export interface ModalSubmitChannelSelectComponent extends ModalSubmitComponentsStringValues<ComponentTypes.CHANNEL_SELECT> {}
 
 export type ApplicationCommandTypesWithTarget = ApplicationCommandTypes.USER | ApplicationCommandTypes.MESSAGE;
 

--- a/lib/types/interactions.d.ts
+++ b/lib/types/interactions.d.ts
@@ -185,14 +185,30 @@ export interface MessageComponentSelectMenuInteractionData {
     values: SelectMenuValuesWrapper;
 }
 
+export interface RawModalSubmitInteractionResolvedData {
+    channels?: Record<string, RawInteractionResolvedChannel>;
+    members?: Record<string, Omit<RawMember, "user" | "deaf" | "mute">>;
+    roles?: Record<string, RawRole>;
+    users?: Record<string, RawUser>;
+}
+
+export interface ModalSubmitInteractionResolvedData {
+    channels: TypedCollection<RawInteractionResolvedChannel, InteractionResolvedChannel>;
+    members: TypedCollection<RawMember, Member, [guildID: string]>;
+    roles: TypedCollection<RawRole, Role, [guildID: string]>;
+    users: TypedCollection<RawUser, User>;
+}
+
 export interface RawModalSubmitInteractionData {
     components: Array<RawModalSubmitComponentsActionRow>;
     custom_id: string;
+    resolved?: RawModalSubmitInteractionResolvedData;
 }
 
 export interface ModalSubmitInteractionData {
     components: ModalSubmitInteractionComponentsWrapper;
     customID: string;
+    resolved: ModalSubmitInteractionResolvedData;
 }
 
 export interface RawApplicationCommandInteractionResolvedData {

--- a/lib/util/Util.ts
+++ b/lib/util/Util.ts
@@ -63,7 +63,8 @@ import type {
     RawMessageComponent,
     RawModalComponent,
     RawModalSubmitComponentsLabel,
-    ModalSubmitComponentsLabel
+    ModalSubmitComponentsLabel,
+    AnyRawBaseComponent
 } from "../types";
 import Message from "../structures/Message";
 import Entitlement from "../structures/Entitlement";
@@ -329,6 +330,7 @@ export default class Util {
                     max_values:  component.maxValues,
                     min_values:  component.minValues,
                     placeholder: component.placeholder,
+                    required:    component.required,
                     type:        component.type
                 };
 
@@ -337,7 +339,7 @@ export default class Util {
                 }
 
                 if (component.type === ComponentTypes.STRING_SELECT) {
-                    return { ...rawComponent, options: component.options, required: component.required } as never;
+                    return { ...rawComponent, options: component.options } as never;
                 } else if (component.type === ComponentTypes.CHANNEL_SELECT) {
                     return { ...rawComponent, channel_types: component.channelTypes } as never;
                 } else {
@@ -384,7 +386,7 @@ export default class Util {
         }
     }
 
-    componentsToParsed<T extends RawMessageComponent | RawModalComponent>(components: Array<T>): Array<T extends RawMessageComponent ? MessageComponent : T extends RawModalComponent ? ModalComponent : never> {
+    componentsToParsed<T extends AnyRawBaseComponent>(components: Array<T>): Array<ToComponentFromRaw<T>> {
         return components.map(component => this.componentToParsed(component)) as never;
     }
 
@@ -630,7 +632,12 @@ export default class Util {
                     value:    component.value
                 } as never;
             }
-            case ComponentTypes.STRING_SELECT: {
+
+            case ComponentTypes.STRING_SELECT:
+            case ComponentTypes.USER_SELECT:
+            case ComponentTypes.ROLE_SELECT:
+            case ComponentTypes.MENTIONABLE_SELECT:
+            case ComponentTypes.CHANNEL_SELECT: {
                 return {
                     customID: component.custom_id,
                     type:     component.type,

--- a/lib/util/interactions/ModalSubmitInteractionComponentsWrapper.ts
+++ b/lib/util/interactions/ModalSubmitInteractionComponentsWrapper.ts
@@ -22,7 +22,7 @@ export default class ModalSubmitInteractionComponentsWrapper {
 
     /** Get the components in this interaction. */
     getComponents(): Array<ModalSubmitComponents> {
-        return this.raw.reduce((a, b) => a.concat(...(b.type === ComponentTypes.ACTION_ROW ? b.components : [b.component])), [] as Array<ModalSubmitComponents>);
+        return this.raw.reduce((a, b) => a.concat(...(b.type === ComponentTypes.ACTION_ROW ? b.components : [b.component])), [] as Array<ModalSubmitComponents>).filter(Boolean);
     }
 
     /**

--- a/lib/util/interactions/ModalSubmitInteractionComponentsWrapper.ts
+++ b/lib/util/interactions/ModalSubmitInteractionComponentsWrapper.ts
@@ -1,7 +1,17 @@
 /** @module ModalSubmitInteractionComponentsWrapper */
 import { WrapperError } from "../Errors";
 import { ComponentTypes, type ModalComponentTypes } from "../../Constants";
-import type { ModalSubmitComponents, ModalSubmitComponentsActionRow, ModalSubmitComponentsLabel, ModalSubmitTextInputComponent } from "../../types/interactions";
+import type {
+    ModalSubmitChannelSelectComponent,
+    ModalSubmitComponents,
+    ModalSubmitComponentsActionRow,
+    ModalSubmitComponentsLabel,
+    ModalSubmitMentionableSelectComponent,
+    ModalSubmitRoleSelectComponent,
+    ModalSubmitStringSelectComponent,
+    ModalSubmitTextInputComponent,
+    ModalSubmitUserSelectComponent
+} from "../../types/interactions";
 
 /** A wrapper for interaction components. */
 export default class ModalSubmitInteractionComponentsWrapper {
@@ -20,13 +30,101 @@ export default class ModalSubmitInteractionComponentsWrapper {
         }
     }
 
+    /**
+     * Get a channel select option value.
+     * @param name The name of the option.
+     * @param required If true, an error will be thrown if the option is not present.
+     */
+    getChannelSelect<T extends Array<string> = Array<string>>(name: string, required?: false): T | undefined;
+    getChannelSelect<T extends Array<string> = Array<string>>(name: string, required: true): T;
+    getChannelSelect(name: string, required?: boolean): Array<string> | undefined {
+        return this.getChannelSelectComponent(name, required as false)?.value;
+    }
+
+    /**
+     * Get a channel select option.
+     * @param name The name of the option.
+     * @param required If true, an error will be thrown if the option is not present.
+     */
+    getChannelSelectComponent(name: string, required?: false): ModalSubmitChannelSelectComponent | undefined;
+    getChannelSelectComponent(name: string, required: true): ModalSubmitChannelSelectComponent;
+    getChannelSelectComponent(name: string, required?: boolean): ModalSubmitChannelSelectComponent | undefined {
+        return this._getComponent(name, required, ComponentTypes.CHANNEL_SELECT);
+    }
+
     /** Get the components in this interaction. */
     getComponents(): Array<ModalSubmitComponents> {
         return this.raw.reduce((a, b) => a.concat(...(b.type === ComponentTypes.ACTION_ROW ? b.components : [b.component])), [] as Array<ModalSubmitComponents>).filter(Boolean);
     }
 
     /**
-     * Get a string option value.
+     * Get a mentionable select option value.
+     * @param name The name of the option.
+     * @param required If true, an error will be thrown if the option is not present.
+     */
+    getMentionableSelect<T extends Array<string> = Array<string>>(name: string, required?: false): T | undefined;
+    getMentionableSelect<T extends Array<string> = Array<string>>(name: string, required: true): T;
+    getMentionableSelect(name: string, required?: boolean): Array<string> | undefined {
+        return this.getMentionableSelectComponent(name, required as false)?.value;
+    }
+
+    /**
+     * Get a mentionable select option.
+     * @param name The name of the option.
+     * @param required If true, an error will be thrown if the option is not present.
+     */
+    getMentionableSelectComponent(name: string, required?: false): ModalSubmitMentionableSelectComponent | undefined;
+    getMentionableSelectComponent(name: string, required: true): ModalSubmitMentionableSelectComponent;
+    getMentionableSelectComponent(name: string, required?: boolean): ModalSubmitMentionableSelectComponent | undefined {
+        return this._getComponent(name, required, ComponentTypes.MENTIONABLE_SELECT);
+    }
+
+    /**
+     * Get a role select option value.
+     * @param name The name of the option.
+     * @param required If true, an error will be thrown if the option is not present.
+     */
+    getRoleSelect<T extends Array<string> = Array<string>>(name: string, required?: false): T | undefined;
+    getRoleSelect<T extends Array<string> = Array<string>>(name: string, required: true): T;
+    getRoleSelect(name: string, required?: boolean): Array<string> | undefined {
+        return this.getRoleSelectComponent(name, required as false)?.value;
+    }
+
+    /**
+     * Get a role select option.
+     * @param name The name of the option.
+     * @param required If true, an error will be thrown if the option is not present.
+     */
+    getRoleSelectComponent(name: string, required?: false): ModalSubmitRoleSelectComponent | undefined;
+    getRoleSelectComponent(name: string, required: true): ModalSubmitRoleSelectComponent;
+    getRoleSelectComponent(name: string, required?: boolean): ModalSubmitRoleSelectComponent | undefined {
+        return this._getComponent(name, required, ComponentTypes.ROLE_SELECT);
+    }
+
+    /**
+     * Get a string select option value.
+     * @param name The name of the option.
+     * @param required If true, an error will be thrown if the option is not present.
+     */
+    getStringSelect<T extends Array<string> = Array<string>>(name: string, required?: false): T | undefined;
+    getStringSelect<T extends Array<string> = Array<string>>(name: string, required: true): T;
+    getStringSelect(name: string, required?: boolean): Array<string> | undefined {
+        return this.getStringSelectComponent(name, required as false)?.value;
+    }
+
+    /**
+     * Get a string select option.
+     * @param name The name of the option.
+     * @param required If true, an error will be thrown if the option is not present.
+     */
+    getStringSelectComponent(name: string, required?: false): ModalSubmitStringSelectComponent | undefined;
+    getStringSelectComponent(name: string, required: true): ModalSubmitStringSelectComponent;
+    getStringSelectComponent(name: string, required?: boolean): ModalSubmitStringSelectComponent | undefined {
+        return this._getComponent(name, required, ComponentTypes.STRING_SELECT);
+    }
+
+    /**
+     * Get a text input option value.
      * @param name The name of the option.
      * @param required If true, an error will be thrown if the option is not present.
      */
@@ -37,7 +135,7 @@ export default class ModalSubmitInteractionComponentsWrapper {
     }
 
     /**
-     * Get a string option.
+     * Get a text input option.
      * @param name The name of the option.
      * @param required If true, an error will be thrown if the option is not present.
      */
@@ -45,5 +143,27 @@ export default class ModalSubmitInteractionComponentsWrapper {
     getTextInputComponent(name: string, required: true): ModalSubmitTextInputComponent;
     getTextInputComponent(name: string, required?: boolean): ModalSubmitTextInputComponent | undefined {
         return this._getComponent(name, required, ComponentTypes.TEXT_INPUT);
+    }
+
+    /**
+     * Get a user select option value.
+     * @param name The name of the option.
+     * @param required If true, an error will be thrown if the option is not present.
+     */
+    getUserSelect<T extends Array<string> = Array<string>>(name: string, required?: false): T | undefined;
+    getUserSelect<T extends Array<string> = Array<string>>(name: string, required: true): T;
+    getUserSelect(name: string, required?: boolean): Array<string> | undefined {
+        return this.getUserSelectComponent(name, required as false)?.value;
+    }
+
+    /**
+     * Get a user select option.
+     * @param name The name of the option.
+     * @param required If true, an error will be thrown if the option is not present.
+     */
+    getUserSelectComponent(name: string, required?: false): ModalSubmitUserSelectComponent | undefined;
+    getUserSelectComponent(name: string, required: true): ModalSubmitUserSelectComponent;
+    getUserSelectComponent(name: string, required?: boolean): ModalSubmitUserSelectComponent | undefined {
+        return this._getComponent(name, required, ComponentTypes.USER_SELECT);
     }
 }


### PR DESCRIPTION
Text displays can now be used as top-level modal components, and Select Menus for users, roles, channels, and mentionables can be used inside Labels/ActionRows. This adheres to the upcoming Phase 2 modal/component changes.