### PR TITLE
Modal Selects: fix and improve get[Structure]Select methods

### DIFF
--- a/lib/structures/ModalSubmitInteraction.ts
+++ b/lib/structures/ModalSubmitInteraction.ts
@@ -127,7 +127,7 @@ export default class ModalSubmitInteraction<T extends AnyInteractionChannel | Un
         }
 
         this.data = {
-            components: new ModalSubmitInteractionComponentsWrapper(client.util.modalSubmitComponentsToParsed(data.data.components)),
+            components: new ModalSubmitInteractionComponentsWrapper(resolved, client.util.modalSubmitComponentsToParsed(data.data.components)),
             customID:   data.data.custom_id,
             resolved
         };

--- a/lib/types/interactions.d.ts
+++ b/lib/types/interactions.d.ts
@@ -417,7 +417,7 @@ export interface ModalSubmitComponentsStringValue<T extends ModalComponentTypes 
 
 export interface ModalSubmitComponentsStringValues<T extends ModalComponentTypes = ModalComponentTypes> extends ModalSubmitComponentsBase {
     type: T;
-    value: Array<string>;
+    values: Array<string>;
 }
 
 export type ToRawFromoModalSubmitComponent<T extends ModalSubmitComponents> =

--- a/lib/util/interactions/ModalSubmitInteractionComponentsWrapper.ts
+++ b/lib/util/interactions/ModalSubmitInteractionComponentsWrapper.ts
@@ -31,14 +31,14 @@ export default class ModalSubmitInteractionComponentsWrapper {
     }
 
     /**
-     * Get a channel select option value.
+     * Get the values of a channel select option. This always returns an array, since selects can be multi-choice.
      * @param name The name of the option.
      * @param required If true, an error will be thrown if the option is not present.
      */
     getChannelSelect<T extends Array<string> = Array<string>>(name: string, required?: false): T | undefined;
     getChannelSelect<T extends Array<string> = Array<string>>(name: string, required: true): T;
     getChannelSelect(name: string, required?: boolean): Array<string> | undefined {
-        return this.getChannelSelectComponent(name, required as false)?.value;
+        return this.getChannelSelectComponent(name, required as false)?.values;
     }
 
     /**
@@ -58,14 +58,14 @@ export default class ModalSubmitInteractionComponentsWrapper {
     }
 
     /**
-     * Get a mentionable select option value.
+     * Get the values of a mentionable select option. This always returns an array, since selects can be multi-choice.
      * @param name The name of the option.
      * @param required If true, an error will be thrown if the option is not present.
      */
     getMentionableSelect<T extends Array<string> = Array<string>>(name: string, required?: false): T | undefined;
     getMentionableSelect<T extends Array<string> = Array<string>>(name: string, required: true): T;
     getMentionableSelect(name: string, required?: boolean): Array<string> | undefined {
-        return this.getMentionableSelectComponent(name, required as false)?.value;
+        return this.getMentionableSelectComponent(name, required as false)?.values;
     }
 
     /**
@@ -80,14 +80,14 @@ export default class ModalSubmitInteractionComponentsWrapper {
     }
 
     /**
-     * Get a role select option value.
+     * Get the values of a role select option. This always returns an array, since selects can be multi-choice.
      * @param name The name of the option.
      * @param required If true, an error will be thrown if the option is not present.
      */
     getRoleSelect<T extends Array<string> = Array<string>>(name: string, required?: false): T | undefined;
     getRoleSelect<T extends Array<string> = Array<string>>(name: string, required: true): T;
     getRoleSelect(name: string, required?: boolean): Array<string> | undefined {
-        return this.getRoleSelectComponent(name, required as false)?.value;
+        return this.getRoleSelectComponent(name, required as false)?.values;
     }
 
     /**
@@ -102,14 +102,14 @@ export default class ModalSubmitInteractionComponentsWrapper {
     }
 
     /**
-     * Get a string select option value.
+     * Get the values of a string select option. This always returns an array, since selects can be multi-choice.
      * @param name The name of the option.
      * @param required If true, an error will be thrown if the option is not present.
      */
     getStringSelect<T extends Array<string> = Array<string>>(name: string, required?: false): T | undefined;
     getStringSelect<T extends Array<string> = Array<string>>(name: string, required: true): T;
     getStringSelect(name: string, required?: boolean): Array<string> | undefined {
-        return this.getStringSelectComponent(name, required as false)?.value;
+        return this.getStringSelectComponent(name, required as false)?.values;
     }
 
     /**
@@ -146,14 +146,14 @@ export default class ModalSubmitInteractionComponentsWrapper {
     }
 
     /**
-     * Get a user select option value.
+     * Get the values of a user select option. This always returns an array, since selects can be multi-choice.
      * @param name The name of the option.
      * @param required If true, an error will be thrown if the option is not present.
      */
     getUserSelect<T extends Array<string> = Array<string>>(name: string, required?: false): T | undefined;
     getUserSelect<T extends Array<string> = Array<string>>(name: string, required: true): T;
     getUserSelect(name: string, required?: boolean): Array<string> | undefined {
-        return this.getUserSelectComponent(name, required as false)?.value;
+        return this.getUserSelectComponent(name, required as false)?.values;
     }
 
     /**

--- a/lib/util/interactions/ModalSubmitInteractionComponentsWrapper.ts
+++ b/lib/util/interactions/ModalSubmitInteractionComponentsWrapper.ts
@@ -1,5 +1,5 @@
 /** @module ModalSubmitInteractionComponentsWrapper */
-import { mapRawToTransformed } from "./shared";
+import { mapRawToResolved } from "./shared";
 import { WrapperError } from "../Errors";
 import { ComponentTypes, type ModalComponentTypes } from "../../Constants";
 import type {
@@ -58,12 +58,12 @@ export default class ModalSubmitInteractionComponentsWrapper {
     getChannelSelectValues(name: string, required: true): Array<InteractionResolvedChannel>;
     getChannelSelectValues(name: string, required?: boolean): Array<InteractionResolvedChannel> | undefined {
         const component = this.getChannelSelectComponent(name, required as false);
-        return component?.values && mapRawToTransformed("channel", component.values, this.resolved.channels, false);
+        return component?.values && mapRawToResolved("channel", component.values, this.resolved.channels, false);
     }
 
     /** Get the components in this interaction. */
     getComponents(): Array<ModalSubmitComponents> {
-        return this.raw.reduce((a, b) => a.concat(...(b.type === ComponentTypes.ACTION_ROW ? b.components : [b.component])), [] as Array<ModalSubmitComponents>).filter(Boolean);
+        return this.raw.flatMap(r => r.type === ComponentTypes.ACTION_ROW ? r.components : r.component).filter(Boolean);
     }
 
     /**
@@ -86,7 +86,7 @@ export default class ModalSubmitInteractionComponentsWrapper {
     getMentionableSelectValues(name: string, required: true): Array<User | Role>;
     getMentionableSelectValues(name: string, required?: boolean): Array<User | Role> | undefined {
         const component = this.getMentionableSelectComponent(name, required as false);
-        return component?.values && mapRawToTransformed("mentionable", component.values, new Collection<string, User | Role>([...this.resolved.users, ...this.resolved.roles]), false);
+        return component?.values && mapRawToResolved("mentionable", component.values, new Collection<string, User | Role>([...this.resolved.users, ...this.resolved.roles]), false);
     }
 
     /**
@@ -109,7 +109,7 @@ export default class ModalSubmitInteractionComponentsWrapper {
     getRoleSelectValues(name: string, required: true): Array<Role>;
     getRoleSelectValues(name: string, required?: boolean): Array<Role> | undefined {
         const component = this.getRoleSelectComponent(name, required as false);
-        return component?.values && mapRawToTransformed("role", component.values, this.resolved.roles, false);
+        return component?.values && mapRawToResolved("role", component.values, this.resolved.roles, false);
     }
 
     /**
@@ -176,6 +176,6 @@ export default class ModalSubmitInteractionComponentsWrapper {
     getUserSelectValues(name: string, required: true): Array<User>;
     getUserSelectValues(name: string, required?: boolean): Array<User> | undefined {
         const component = this.getUserSelectComponent(name, required as false);
-        return component?.values && mapRawToTransformed("user", component.values, this.resolved.users, false);
+        return component?.values && mapRawToResolved("user", component.values, this.resolved.users, false);
     }
 }

--- a/lib/util/interactions/ModalSubmitInteractionComponentsWrapper.ts
+++ b/lib/util/interactions/ModalSubmitInteractionComponentsWrapper.ts
@@ -1,7 +1,9 @@
 /** @module ModalSubmitInteractionComponentsWrapper */
+import { mapRawToTransformed } from "./shared";
 import { WrapperError } from "../Errors";
 import { ComponentTypes, type ModalComponentTypes } from "../../Constants";
 import type {
+    MessageComponentInteractionResolvedData,
     ModalSubmitChannelSelectComponent,
     ModalSubmitComponents,
     ModalSubmitComponentsActionRow,
@@ -12,13 +14,19 @@ import type {
     ModalSubmitTextInputComponent,
     ModalSubmitUserSelectComponent
 } from "../../types/interactions";
+import type Role from "../../structures/Role";
+import type User from "../../structures/User";
+import Collection from "../Collection";
+import type InteractionResolvedChannel from "../../structures/InteractionResolvedChannel";
 
 /** A wrapper for interaction components. */
 export default class ModalSubmitInteractionComponentsWrapper {
     /** The raw components from Discord.  */
     raw: Array<ModalSubmitComponentsActionRow | ModalSubmitComponentsLabel>;
-    constructor(data: Array<ModalSubmitComponentsActionRow | ModalSubmitComponentsLabel>) {
+    resolved: MessageComponentInteractionResolvedData;
+    constructor(resolved: MessageComponentInteractionResolvedData, data: Array<ModalSubmitComponentsActionRow | ModalSubmitComponentsLabel>) {
         this.raw = data;
+        this.resolved = resolved;
     }
 
     private _getComponent<T extends ModalSubmitComponents = ModalSubmitComponents>(customID: string, required = false, type: ModalComponentTypes): T | undefined {
@@ -28,17 +36,6 @@ export default class ModalSubmitInteractionComponentsWrapper {
         } else {
             return opt;
         }
-    }
-
-    /**
-     * Get the values of a channel select option. This always returns an array, since selects can be multi-choice.
-     * @param name The name of the option.
-     * @param required If true, an error will be thrown if the option is not present.
-     */
-    getChannelSelect<T extends Array<string> = Array<string>>(name: string, required?: false): T | undefined;
-    getChannelSelect<T extends Array<string> = Array<string>>(name: string, required: true): T;
-    getChannelSelect(name: string, required?: boolean): Array<string> | undefined {
-        return this.getChannelSelectComponent(name, required as false)?.values;
     }
 
     /**
@@ -52,20 +49,21 @@ export default class ModalSubmitInteractionComponentsWrapper {
         return this._getComponent(name, required, ComponentTypes.CHANNEL_SELECT);
     }
 
-    /** Get the components in this interaction. */
-    getComponents(): Array<ModalSubmitComponents> {
-        return this.raw.reduce((a, b) => a.concat(...(b.type === ComponentTypes.ACTION_ROW ? b.components : [b.component])), [] as Array<ModalSubmitComponents>).filter(Boolean);
-    }
-
     /**
-     * Get the values of a mentionable select option. This always returns an array, since selects can be multi-choice.
+     * Get the values of a channel select option. This always returns an array, since selects can be multi-choice.
      * @param name The name of the option.
      * @param required If true, an error will be thrown if the option is not present.
      */
-    getMentionableSelect<T extends Array<string> = Array<string>>(name: string, required?: false): T | undefined;
-    getMentionableSelect<T extends Array<string> = Array<string>>(name: string, required: true): T;
-    getMentionableSelect(name: string, required?: boolean): Array<string> | undefined {
-        return this.getMentionableSelectComponent(name, required as false)?.values;
+    getChannelSelectValues(name: string, required?: false): Array<InteractionResolvedChannel> | undefined;
+    getChannelSelectValues(name: string, required: true): Array<InteractionResolvedChannel>;
+    getChannelSelectValues(name: string, required?: boolean): Array<InteractionResolvedChannel> | undefined {
+        const component = this.getChannelSelectComponent(name, required as false);
+        return component?.values && mapRawToTransformed("channel", component.values, this.resolved.channels, false);
+    }
+
+    /** Get the components in this interaction. */
+    getComponents(): Array<ModalSubmitComponents> {
+        return this.raw.reduce((a, b) => a.concat(...(b.type === ComponentTypes.ACTION_ROW ? b.components : [b.component])), [] as Array<ModalSubmitComponents>).filter(Boolean);
     }
 
     /**
@@ -80,14 +78,15 @@ export default class ModalSubmitInteractionComponentsWrapper {
     }
 
     /**
-     * Get the values of a role select option. This always returns an array, since selects can be multi-choice.
+     * Get the values of a mentionable select option. This always returns an array, since selects can be multi-choice.
      * @param name The name of the option.
      * @param required If true, an error will be thrown if the option is not present.
      */
-    getRoleSelect<T extends Array<string> = Array<string>>(name: string, required?: false): T | undefined;
-    getRoleSelect<T extends Array<string> = Array<string>>(name: string, required: true): T;
-    getRoleSelect(name: string, required?: boolean): Array<string> | undefined {
-        return this.getRoleSelectComponent(name, required as false)?.values;
+    getMentionableSelectValues(name: string, required?: false): Array<User | Role> | undefined;
+    getMentionableSelectValues(name: string, required: true): Array<User | Role>;
+    getMentionableSelectValues(name: string, required?: boolean): Array<User | Role> | undefined {
+        const component = this.getMentionableSelectComponent(name, required as false);
+        return component?.values && mapRawToTransformed("mentionable", component.values, new Collection<string, User | Role>([...this.resolved.users, ...this.resolved.roles]), false);
     }
 
     /**
@@ -102,14 +101,15 @@ export default class ModalSubmitInteractionComponentsWrapper {
     }
 
     /**
-     * Get the values of a string select option. This always returns an array, since selects can be multi-choice.
+     * Get the values of a role select option. This always returns an array, since selects can be multi-choice.
      * @param name The name of the option.
      * @param required If true, an error will be thrown if the option is not present.
      */
-    getStringSelect<T extends Array<string> = Array<string>>(name: string, required?: false): T | undefined;
-    getStringSelect<T extends Array<string> = Array<string>>(name: string, required: true): T;
-    getStringSelect(name: string, required?: boolean): Array<string> | undefined {
-        return this.getStringSelectComponent(name, required as false)?.values;
+    getRoleSelectValues(name: string, required?: false): Array<Role> | undefined;
+    getRoleSelectValues(name: string, required: true): Array<Role>;
+    getRoleSelectValues(name: string, required?: boolean): Array<Role> | undefined {
+        const component = this.getRoleSelectComponent(name, required as false);
+        return component?.values && mapRawToTransformed("role", component.values, this.resolved.roles, false);
     }
 
     /**
@@ -121,6 +121,17 @@ export default class ModalSubmitInteractionComponentsWrapper {
     getStringSelectComponent(name: string, required: true): ModalSubmitStringSelectComponent;
     getStringSelectComponent(name: string, required?: boolean): ModalSubmitStringSelectComponent | undefined {
         return this._getComponent(name, required, ComponentTypes.STRING_SELECT);
+    }
+
+    /**
+     * Get the values of a string select option. This always returns an array, since selects can be multi-choice.
+     * @param name The name of the option.
+     * @param required If true, an error will be thrown if the option is not present.
+     */
+    getStringSelectValues<T extends Array<string> = Array<string>>(name: string, required?: false): T | undefined;
+    getStringSelectValues<T extends Array<string> = Array<string>>(name: string, required: true): T;
+    getStringSelectValues(name: string, required?: boolean): Array<string> | undefined {
+        return this.getStringSelectComponent(name, required as false)?.values;
     }
 
     /**
@@ -146,17 +157,6 @@ export default class ModalSubmitInteractionComponentsWrapper {
     }
 
     /**
-     * Get the values of a user select option. This always returns an array, since selects can be multi-choice.
-     * @param name The name of the option.
-     * @param required If true, an error will be thrown if the option is not present.
-     */
-    getUserSelect<T extends Array<string> = Array<string>>(name: string, required?: false): T | undefined;
-    getUserSelect<T extends Array<string> = Array<string>>(name: string, required: true): T;
-    getUserSelect(name: string, required?: boolean): Array<string> | undefined {
-        return this.getUserSelectComponent(name, required as false)?.values;
-    }
-
-    /**
      * Get a user select option.
      * @param name The name of the option.
      * @param required If true, an error will be thrown if the option is not present.
@@ -165,5 +165,17 @@ export default class ModalSubmitInteractionComponentsWrapper {
     getUserSelectComponent(name: string, required: true): ModalSubmitUserSelectComponent;
     getUserSelectComponent(name: string, required?: boolean): ModalSubmitUserSelectComponent | undefined {
         return this._getComponent(name, required, ComponentTypes.USER_SELECT);
+    }
+
+    /**
+     * Get the values of a user select option. This always returns an array, since selects can be multi-choice.
+     * @param name The name of the option.
+     * @param required If true, an error will be thrown if the option is not present.
+     */
+    getUserSelectValues(name: string, required?: false): Array<User> | undefined;
+    getUserSelectValues(name: string, required: true): Array<User>;
+    getUserSelectValues(name: string, required?: boolean): Array<User> | undefined {
+        const component = this.getUserSelectComponent(name, required as false);
+        return component?.values && mapRawToTransformed("user", component.values, this.resolved.users, false);
     }
 }

--- a/lib/util/interactions/SelectMenuValuesWrapper.ts
+++ b/lib/util/interactions/SelectMenuValuesWrapper.ts
@@ -1,5 +1,5 @@
 /** @module SelectMenuValuesWrapper */
-import { mapRawToTransformed } from "./shared";
+import { mapRawToResolved } from "./shared";
 import { ChannelTypes } from "../../Constants";
 import type Member from "../../structures/Member";
 import type Role from "../../structures/Role";
@@ -27,7 +27,7 @@ export default class SelectMenuValuesWrapper {
      * @param ensurePresent If true, an error will be thrown if any value cannot be mapped to a channel.
      */
     getChannels(ensurePresent?: boolean): Array<InteractionResolvedChannel> {
-        return mapRawToTransformed("channel", this.raw, this.resolved.channels, ensurePresent);
+        return mapRawToResolved("channel", this.raw, this.resolved.channels, ensurePresent);
     }
 
     /**
@@ -47,7 +47,7 @@ export default class SelectMenuValuesWrapper {
      * @param ensurePresent If true, an error will be thrown if any value cannot be mapped to a member.
      */
     getMembers(ensurePresent?: boolean): Array<Member> {
-        return mapRawToTransformed("member", this.raw, this.resolved.members, ensurePresent);
+        return mapRawToResolved("member", this.raw, this.resolved.members, ensurePresent);
     }
 
     /**
@@ -57,7 +57,7 @@ export default class SelectMenuValuesWrapper {
      * @param ensurePresent If true, an error will be thrown if any value cannot be mapped to a user, or role.
      */
     getMentionables(ensurePresent?: boolean): Array<User | Role> {
-        return mapRawToTransformed("mentionable", this.raw, new Collection<string, User | Role>([...this.resolved.users, ...this.resolved.roles]), ensurePresent);
+        return mapRawToResolved("mentionable", this.raw, new Collection<string, User | Role>([...this.resolved.users, ...this.resolved.roles]), ensurePresent);
     }
 
     /**
@@ -67,7 +67,7 @@ export default class SelectMenuValuesWrapper {
      * @param ensurePresent If true, an error will be thrown if any value cannot be mapped to a role.
      */
     getRoles(ensurePresent?: boolean): Array<Role> {
-        return mapRawToTransformed("role", this.raw, this.resolved.roles, ensurePresent);
+        return mapRawToResolved("role", this.raw, this.resolved.roles, ensurePresent);
     }
 
     /**
@@ -84,6 +84,6 @@ export default class SelectMenuValuesWrapper {
      * @param ensurePresent If true, an error will be thrown if any value cannot be mapped to a user.
      */
     getUsers(ensurePresent?: boolean): Array<User> {
-        return mapRawToTransformed("user", this.raw, this.resolved.users, ensurePresent);
+        return mapRawToResolved("user", this.raw, this.resolved.users, ensurePresent);
     }
 }

--- a/lib/util/interactions/SelectMenuValuesWrapper.ts
+++ b/lib/util/interactions/SelectMenuValuesWrapper.ts
@@ -1,5 +1,5 @@
 /** @module SelectMenuValuesWrapper */
-import { WrapperError } from "../Errors";
+import { mapRawToTransformed } from "./shared";
 import { ChannelTypes } from "../../Constants";
 import type Member from "../../structures/Member";
 import type Role from "../../structures/Role";
@@ -7,6 +7,7 @@ import type User from "../../structures/User";
 import type InteractionResolvedChannel from "../../structures/InteractionResolvedChannel";
 import type { AnyImplementedChannel } from "../../types/channels";
 import type { MessageComponentInteractionResolvedData } from "../../types/interactions";
+import Collection from "../Collection";
 
 /** A wrapper for select menu data. */
 export default class SelectMenuValuesWrapper {
@@ -16,7 +17,7 @@ export default class SelectMenuValuesWrapper {
     resolved: MessageComponentInteractionResolvedData;
     constructor(resolved: MessageComponentInteractionResolvedData, values: Array<string>) {
         this.resolved = resolved;
-        this.raw   = values;
+        this.raw = values;
     }
 
     /**
@@ -26,13 +27,7 @@ export default class SelectMenuValuesWrapper {
      * @param ensurePresent If true, an error will be thrown if any value cannot be mapped to a channel.
      */
     getChannels(ensurePresent?: boolean): Array<InteractionResolvedChannel> {
-        return this.raw.map(id => {
-            const ch = this.resolved.channels.get(id);
-            if (!ch && ensurePresent) {
-                throw new WrapperError(`Failed to find channel in resolved data: ${id}`);
-            }
-            return ch!;
-        }).filter(Boolean);
+        return mapRawToTransformed("channel", this.raw, this.resolved.channels, ensurePresent);
     }
 
     /**
@@ -42,16 +37,7 @@ export default class SelectMenuValuesWrapper {
      * @param ensurePresent If true, an error will be thrown if any value cannot be mapped to a channel.
      */
     getCompleteChannels(ensurePresent?: boolean): Array<AnyImplementedChannel | InteractionResolvedChannel> {
-        return this.raw.map(id => {
-            const ch = this.resolved.channels.get(id);
-            if (ch && ch.type === ChannelTypes.DM) {
-                return ch?.completeChannel ?? ch;
-            }
-            if (!ch && ensurePresent) {
-                throw new WrapperError(`Failed to find channel in resolved data: ${id}`);
-            }
-            return ch!;
-        }).filter(Boolean);
+        return this.getChannels(ensurePresent).map(ch => ch.type === ChannelTypes.DM ? ch.completeChannel ?? ch : ch);
     }
 
     /**
@@ -61,13 +47,7 @@ export default class SelectMenuValuesWrapper {
      * @param ensurePresent If true, an error will be thrown if any value cannot be mapped to a member.
      */
     getMembers(ensurePresent?: boolean): Array<Member> {
-        return this.raw.map(id => {
-            const member = this.resolved.members.get(id);
-            if (!member && ensurePresent) {
-                throw new WrapperError(`Failed to find member in resolved data: ${id}`);
-            }
-            return member!;
-        }).filter(Boolean);
+        return mapRawToTransformed("member", this.raw, this.resolved.members, ensurePresent);
     }
 
     /**
@@ -77,20 +57,7 @@ export default class SelectMenuValuesWrapper {
      * @param ensurePresent If true, an error will be thrown if any value cannot be mapped to a user, or role.
      */
     getMentionables(ensurePresent?: boolean): Array<User | Role> {
-        const res: Array<User | Role> = [];
-        for (const id of this.raw) {
-            const role = this.resolved.roles.get(id);
-            const user = this.resolved.users.get(id);
-            if ((!role && !user)) {
-                if (ensurePresent) {
-                    throw new WrapperError(`Failed to find mentionable in resolved data: ${id}`);
-                }
-            } else {
-                res.push((role ?? user)!);
-            }
-        }
-
-        return res;
+        return mapRawToTransformed("mentionable", this.raw, new Collection<string, User | Role>([...this.resolved.users, ...this.resolved.roles]), ensurePresent);
     }
 
     /**
@@ -100,13 +67,7 @@ export default class SelectMenuValuesWrapper {
      * @param ensurePresent If true, an error will be thrown if any value cannot be mapped to a role.
      */
     getRoles(ensurePresent?: boolean): Array<Role> {
-        return this.raw.map(id => {
-            const role = this.resolved.roles.get(id);
-            if (!role && ensurePresent) {
-                throw new WrapperError(`Failed to find role in resolved data: ${id}`);
-            }
-            return role!;
-        }).filter(Boolean);
+        return mapRawToTransformed("role", this.raw, this.resolved.roles, ensurePresent);
     }
 
     /**
@@ -123,12 +84,6 @@ export default class SelectMenuValuesWrapper {
      * @param ensurePresent If true, an error will be thrown if any value cannot be mapped to a user.
      */
     getUsers(ensurePresent?: boolean): Array<User> {
-        return this.raw.map(id => {
-            const user = this.resolved.users.get(id);
-            if (!user && ensurePresent) {
-                throw new WrapperError(`Failed to find user in resolved data: ${id}`);
-            }
-            return user!;
-        }).filter(Boolean);
+        return mapRawToTransformed("user", this.raw, this.resolved.users, ensurePresent);
     }
 }

--- a/lib/util/interactions/shared.ts
+++ b/lib/util/interactions/shared.ts
@@ -1,7 +1,12 @@
 import type Collection from "../Collection";
 import { WrapperError } from "../Errors";
 
-export function mapRawToTransformed<S, R extends Collection<string, S>>(
+/**
+ * Maps raw select menu values to resolved objects.
+ *
+ * If `ensurePresent` is false, values that aren't in resolved will be ignored.
+ */
+export function mapRawToResolved<S, R extends Collection<string, S>>(
     type: string,
     raw: Array<string>,
     resolved: R,

--- a/lib/util/interactions/shared.ts
+++ b/lib/util/interactions/shared.ts
@@ -1,0 +1,19 @@
+import type Collection from "../Collection";
+import { WrapperError } from "../Errors";
+
+export function mapRawToTransformed<S, R extends Collection<string, S>>(
+    type: string,
+    raw: Array<string>,
+    resolved: R,
+    ensurePresent = false
+): Array<S> {
+    return raw
+        .map(id => {
+            const value = resolved.get(id);
+            if (!value && ensurePresent) {
+                throw new WrapperError(`Failed to find ${type} in resolved data: ${id}`);
+            }
+            return value!;
+        })
+        .filter(Boolean);
+}

--- a/lib/util/interactions/shared.ts
+++ b/lib/util/interactions/shared.ts
@@ -4,14 +4,14 @@ import { WrapperError } from "../Errors";
 /**
  * Maps raw select menu values to resolved objects.
  *
- * If `ensurePresent` is false, values that aren't in resolved will be ignored.
+ * If `ensurePresent` is false, values that aren't in `resolved` will be ignored.
  */
-export function mapRawToResolved<S, R extends Collection<string, S>>(
+export function mapRawToResolved<T, R extends Collection<string, T>>(
     type: string,
     raw: Array<string>,
     resolved: R,
     ensurePresent = false
-): Array<S> {
+): Array<T> {
     return raw
         .map(id => {
             const value = resolved.get(id);


### PR DESCRIPTION
The property is named `values`, not `value` - [Discord Docs](https://discord.com/developers/docs/components/reference#string-select-string-select-interaction-response-structure).

I also renamed all functions from `getUserSelect` to `getUserSelectValues` and made them return resolved data (User[]) instead of raw data (string[])

<img width="983" height="178" alt="image" src="https://github.com/user-attachments/assets/17e29ee1-5d79-41bb-82b8-cbfb26054527" />
<img width="749" height="200" alt="image" src="https://github.com/user-attachments/assets/d66b26e8-2ea0-4aef-82bd-3cfe38048715" />