### PR TITLE
Add file upload component

### DIFF
--- a/lib/Constants.ts
+++ b/lib/Constants.ts
@@ -816,14 +816,15 @@ export enum ComponentTypes {
     CONTENT_INVENTORY_ENTRY = 16,
     CONTAINER               = 17,
     LABEL                   = 18,
+    FILE_UPLOAD             = 19,
 }
 
 export type SelectMenuNonResolvedTypes = ComponentTypes.STRING_SELECT;
 export type SelectMenuResolvedTypes = ComponentTypes.USER_SELECT | ComponentTypes.ROLE_SELECT | ComponentTypes.MENTIONABLE_SELECT | ComponentTypes.CHANNEL_SELECT;
 export type SelectMenuTypes = SelectMenuNonResolvedTypes | SelectMenuResolvedTypes;
 
-export type MessageComponentTypes = ComponentTypes.BUTTON | SelectMenuTypes;
-export type ModalComponentTypes = ComponentTypes.TEXT_INPUT | SelectMenuTypes;
+export type MessageComponentTypes = ComponentTypes.BUTTON | ComponentTypes.FILE_UPLOAD | SelectMenuTypes;
+export type ModalComponentTypes = ComponentTypes.TEXT_INPUT | SelectMenuTypes | ComponentTypes.FILE_UPLOAD;
 
 export enum ButtonStyles {
     PRIMARY   = 1,

--- a/lib/Constants.ts
+++ b/lib/Constants.ts
@@ -823,7 +823,7 @@ export type SelectMenuNonResolvedTypes = ComponentTypes.STRING_SELECT;
 export type SelectMenuResolvedTypes = ComponentTypes.USER_SELECT | ComponentTypes.ROLE_SELECT | ComponentTypes.MENTIONABLE_SELECT | ComponentTypes.CHANNEL_SELECT;
 export type SelectMenuTypes = SelectMenuNonResolvedTypes | SelectMenuResolvedTypes;
 
-export type MessageComponentTypes = ComponentTypes.BUTTON | ComponentTypes.FILE_UPLOAD | SelectMenuTypes;
+export type MessageComponentTypes = ComponentTypes.BUTTON | SelectMenuTypes;
 export type ModalComponentTypes = ComponentTypes.TEXT_INPUT | SelectMenuTypes | ComponentTypes.FILE_UPLOAD;
 
 export enum ButtonStyles {

--- a/lib/structures/ComponentInteraction.ts
+++ b/lib/structures/ComponentInteraction.ts
@@ -11,6 +11,7 @@ import User from "./User";
 import InteractionResolvedChannel from "./InteractionResolvedChannel";
 import type Entitlement from "./Entitlement";
 import type TestEntitlement from "./TestEntitlement";
+import Attachment from "./Attachment";
 import type Client from "../Client";
 import type {
     AuthorizingIntegrationOwners,
@@ -109,15 +110,21 @@ export default class ComponentInteraction<V extends ComponentTypes.BUTTON | Sele
             case ComponentTypes.USER_SELECT:
             case ComponentTypes.ROLE_SELECT:
             case ComponentTypes.MENTIONABLE_SELECT:
-            case ComponentTypes.CHANNEL_SELECT: {
+            case ComponentTypes.CHANNEL_SELECT:
+            case ComponentTypes.FILE_UPLOAD: {
                 const resolved: MessageComponentInteractionResolvedData = {
-                    channels: new TypedCollection(InteractionResolvedChannel, client),
-                    members:  new TypedCollection(Member, client),
-                    roles:    new TypedCollection(Role, client),
-                    users:    new TypedCollection(User, client)
+                    channels:    new TypedCollection(InteractionResolvedChannel, client),
+                    members:     new TypedCollection(Member, client),
+                    roles:       new TypedCollection(Role, client),
+                    users:       new TypedCollection(User, client),
+                    attachments: new TypedCollection(Attachment, client)
                 };
 
                 if (data.data.resolved) {
+                    if (data.data.resolved.attachments) {
+                        for (const attachment of Object.values(data.data.resolved.attachments)) resolved.attachments.update(new Attachment(attachment, client));
+                    }
+
                     if (data.data.resolved.channels) {
                         for (const channel of Object.values(data.data.resolved.channels)) resolved.channels.update(channel);
                     }

--- a/lib/structures/ComponentInteraction.ts
+++ b/lib/structures/ComponentInteraction.ts
@@ -11,7 +11,6 @@ import User from "./User";
 import InteractionResolvedChannel from "./InteractionResolvedChannel";
 import type Entitlement from "./Entitlement";
 import type TestEntitlement from "./TestEntitlement";
-import Attachment from "./Attachment";
 import type Client from "../Client";
 import type {
     AuthorizingIntegrationOwners,
@@ -110,21 +109,15 @@ export default class ComponentInteraction<V extends ComponentTypes.BUTTON | Sele
             case ComponentTypes.USER_SELECT:
             case ComponentTypes.ROLE_SELECT:
             case ComponentTypes.MENTIONABLE_SELECT:
-            case ComponentTypes.CHANNEL_SELECT:
-            case ComponentTypes.FILE_UPLOAD: {
+            case ComponentTypes.CHANNEL_SELECT: {
                 const resolved: MessageComponentInteractionResolvedData = {
-                    channels:    new TypedCollection(InteractionResolvedChannel, client),
-                    members:     new TypedCollection(Member, client),
-                    roles:       new TypedCollection(Role, client),
-                    users:       new TypedCollection(User, client),
-                    attachments: new TypedCollection(Attachment, client)
+                    channels: new TypedCollection(InteractionResolvedChannel, client),
+                    members:  new TypedCollection(Member, client),
+                    roles:    new TypedCollection(Role, client),
+                    users:    new TypedCollection(User, client)
                 };
 
                 if (data.data.resolved) {
-                    if (data.data.resolved.attachments) {
-                        for (const attachment of Object.values(data.data.resolved.attachments)) resolved.attachments.update(new Attachment(attachment, client));
-                    }
-
                     if (data.data.resolved.channels) {
                         for (const channel of Object.values(data.data.resolved.channels)) resolved.channels.update(channel);
                     }

--- a/lib/structures/ModalSubmitInteraction.ts
+++ b/lib/structures/ModalSubmitInteraction.ts
@@ -11,6 +11,7 @@ import type Entitlement from "./Entitlement";
 import type TestEntitlement from "./TestEntitlement";
 import InteractionResolvedChannel from "./InteractionResolvedChannel";
 import Role from "./Role";
+import Attachment from "./Attachment";
 import { InteractionResponseTypes, type InteractionTypes, type InteractionContextTypes } from "../Constants";
 import type {
     AuthorizingIntegrationOwners,
@@ -92,13 +93,18 @@ export default class ModalSubmitInteraction<T extends AnyInteractionChannel | Un
         this.user = client.users.update(data.user ?? data.member!.user);
 
         const resolved: ModalSubmitInteractionResolvedData = {
-            channels: new TypedCollection(InteractionResolvedChannel, client),
-            members:  new TypedCollection(Member, client),
-            roles:    new TypedCollection(Role, client),
-            users:    new TypedCollection(User, client)
+            attachments: new TypedCollection(Attachment, client),
+            channels:    new TypedCollection(InteractionResolvedChannel, client),
+            members:     new TypedCollection(Member, client),
+            roles:       new TypedCollection(Role, client),
+            users:       new TypedCollection(User, client)
         };
 
         if (data.data.resolved) {
+            if (data.data.resolved.attachments) {
+                for (const attachment of Object.values(data.data.resolved.attachments)) resolved.attachments.add(new Attachment(attachment, client));
+            }
+
             if (data.data.resolved.channels) {
                 for (const channel of Object.values(data.data.resolved.channels)) resolved.channels.update(channel);
             }

--- a/lib/types/channels.d.ts
+++ b/lib/types/channels.d.ts
@@ -1219,10 +1219,10 @@ export interface RawSectionComponent extends BaseComponent {
 
 export type RawComponent = AnyRawMessageComponent | AnyRawModalComponent;
 export type AnyRawMessageComponent = RawMessageComponent | RawMessageActionRowComponent | RawThumbnailComponent;
-export type AnyRawModalComponent = RawModalComponent | RawModalActionRowComponent | RawModalLabelComponent;
+export type AnyRawModalComponent = RawModalComponent | RawModalActionRowComponent | RawModalLabelComponent | RawFileUploadComponent;
 export type AnyRawBaseComponent = RawMessageComponent | RawModalComponent;
 export type RawMessageActionRowComponent = RawButtonComponent | RawSelectMenuComponent;
-export type RawMessageComponent = RawMessageActionRow | RawSectionComponent | RawTextDisplayComponent | RawMediaGalleryComponent | RawSeparatorComponent | RawFileComponent | RawContainerComponent | RawFileUploadComponent;
+export type RawMessageComponent = RawMessageActionRow | RawSectionComponent | RawTextDisplayComponent | RawMediaGalleryComponent | RawSeparatorComponent | RawFileComponent | RawContainerComponent;
 /** @deprecated */
 export type RawModalActionRowComponent = RawTextInput;
 export type RawModalLabelComponent = RawSelectMenuComponent | RawTextInput;
@@ -1286,11 +1286,11 @@ export type ActionRowToRaw<T extends MessageActionRow | ModalActionRow> =
         T extends ModalActionRow ? RawModalActionRow : never;
 
 export type Component = AnyMessageComponent | AnyModalComponent;
-export type AnyMessageComponent = MessageComponent | MessageActionRowComponent | ThumbnailComponent | FileUploadComponent;
+export type AnyMessageComponent = MessageComponent | MessageActionRowComponent | ThumbnailComponent;
 export type AnyModalComponent = ModalComponent | ModalActionRowComponent | ModalLabelComponent | FileUploadComponent;
 export type AnyBaseComponent = MessageComponent | ModalComponent;
 export type MessageActionRowComponent = ButtonComponent | SelectMenuComponent;
-export type MessageComponent = MessageActionRow | SectionComponent | TextDisplayComponent | MediaGalleryComponent | SeparatorComponent | FileComponent | ContainerComponent | FileUploadComponent;
+export type MessageComponent = MessageActionRow | SectionComponent | TextDisplayComponent | MediaGalleryComponent | SeparatorComponent | FileComponent | ContainerComponent;
 /** @deprecated */
 export type ModalActionRowComponent = TextInput;
 export type ModalLabelComponent = SelectMenuComponent | TextInput;

--- a/lib/types/channels.d.ts
+++ b/lib/types/channels.d.ts
@@ -1222,7 +1222,7 @@ export type AnyRawMessageComponent = RawMessageComponent | RawMessageActionRowCo
 export type AnyRawModalComponent = RawModalComponent | RawModalActionRowComponent | RawModalLabelComponent;
 export type AnyRawBaseComponent = RawMessageComponent | RawModalComponent;
 export type RawMessageActionRowComponent = RawButtonComponent | RawSelectMenuComponent;
-export type RawMessageComponent = RawMessageActionRow | RawSectionComponent | RawTextDisplayComponent | RawMediaGalleryComponent | RawSeparatorComponent | RawFileComponent | RawContainerComponent;
+export type RawMessageComponent = RawMessageActionRow | RawSectionComponent | RawTextDisplayComponent | RawMediaGalleryComponent | RawSeparatorComponent | RawFileComponent | RawContainerComponent | RawFileUploadComponent;
 /** @deprecated */
 export type RawModalActionRowComponent = RawTextInput;
 export type RawModalLabelComponent = RawSelectMenuComponent | RawTextInput;
@@ -1249,7 +1249,8 @@ export type ToComponentFromRaw<T extends RawComponent> =
                                                                 T extends RawFileComponent ? FileComponent :
                                                                     T extends RawContainerComponent ? ContainerComponent :
                                                                         T extends RawModalLabel ? ModalLabel :
-                                                                            never;
+                                                                            T extends RawFileUploadComponent ? FileUploadComponent :
+                                                                                never;
 export type ToRawFromComponent<T extends Component> =
     T extends MessageActionRow ? RawMessageActionRow :
         T extends ModalActionRow ? RawModalActionRow :
@@ -1269,7 +1270,8 @@ export type ToRawFromComponent<T extends Component> =
                                                                 T extends FileComponent ? RawFileComponent :
                                                                     T extends ContainerComponent ? RawContainerComponent :
                                                                         T extends ModalLabel ? RawModalLabel :
-                                                                            never;
+                                                                            T extends FileUploadComponent ? RawFileUploadComponent :
+                                                                                never;
 
 export interface RawActionRowBase<T extends RawComponent> {
     components: Array<T>;
@@ -1284,11 +1286,11 @@ export type ActionRowToRaw<T extends MessageActionRow | ModalActionRow> =
         T extends ModalActionRow ? RawModalActionRow : never;
 
 export type Component = AnyMessageComponent | AnyModalComponent;
-export type AnyMessageComponent = MessageComponent | MessageActionRowComponent | ThumbnailComponent;
-export type AnyModalComponent = ModalComponent | ModalActionRowComponent | ModalLabelComponent;
+export type AnyMessageComponent = MessageComponent | MessageActionRowComponent | ThumbnailComponent | FileUploadComponent;
+export type AnyModalComponent = ModalComponent | ModalActionRowComponent | ModalLabelComponent | FileUploadComponent;
 export type AnyBaseComponent = MessageComponent | ModalComponent;
 export type MessageActionRowComponent = ButtonComponent | SelectMenuComponent;
-export type MessageComponent = MessageActionRow | SectionComponent | TextDisplayComponent | MediaGalleryComponent | SeparatorComponent | FileComponent | ContainerComponent;
+export type MessageComponent = MessageActionRow | SectionComponent | TextDisplayComponent | MediaGalleryComponent | SeparatorComponent | FileComponent | ContainerComponent | FileUploadComponent;
 /** @deprecated */
 export type ModalActionRowComponent = TextInput;
 export type ModalLabelComponent = SelectMenuComponent | TextInput;
@@ -1507,4 +1509,20 @@ export interface RawModalLabel extends Omit<BaseComponent, "id"> {
     description?: string;
     label: string;
     type: ComponentTypes.LABEL;
+}
+
+export interface FileUploadComponent extends BaseComponent {
+    customID: string;
+    maxValues?: number;
+    minValues?: number;
+    required?: boolean;
+    type: ComponentTypes.FILE_UPLOAD;
+}
+
+export interface RawFileUploadComponent extends BaseComponent {
+    custom_id: string;
+    max_values?: number;
+    min_values?: number;
+    required?: boolean;
+    type: ComponentTypes.FILE_UPLOAD;
 }

--- a/lib/types/channels.d.ts
+++ b/lib/types/channels.d.ts
@@ -1219,13 +1219,13 @@ export interface RawSectionComponent extends BaseComponent {
 
 export type RawComponent = AnyRawMessageComponent | AnyRawModalComponent;
 export type AnyRawMessageComponent = RawMessageComponent | RawMessageActionRowComponent | RawThumbnailComponent;
-export type AnyRawModalComponent = RawModalComponent | RawModalActionRowComponent | RawModalLabelComponent | RawFileUploadComponent;
+export type AnyRawModalComponent = RawModalComponent | RawModalActionRowComponent | RawModalLabelComponent;
 export type AnyRawBaseComponent = RawMessageComponent | RawModalComponent;
 export type RawMessageActionRowComponent = RawButtonComponent | RawSelectMenuComponent;
 export type RawMessageComponent = RawMessageActionRow | RawSectionComponent | RawTextDisplayComponent | RawMediaGalleryComponent | RawSeparatorComponent | RawFileComponent | RawContainerComponent;
 /** @deprecated */
 export type RawModalActionRowComponent = RawTextInput;
-export type RawModalLabelComponent = RawSelectMenuComponent | RawTextInput;
+export type RawModalLabelComponent = RawSelectMenuComponent | RawTextInput | RawFileUploadComponent;
 export type RawModalComponent = RawModalActionRow | RawModalLabel | RawTextDisplayComponent;
 export type RawButtonComponent = RawTextButton | URLButton | RawPremiumButton;
 export type RawSelectMenuComponent = RawStringSelectMenu | RawUserSelectMenu | RawRoleSelectMenu | RawMentionableSelectMenu | RawChannelSelectMenu;
@@ -1287,13 +1287,14 @@ export type ActionRowToRaw<T extends MessageActionRow | ModalActionRow> =
 
 export type Component = AnyMessageComponent | AnyModalComponent;
 export type AnyMessageComponent = MessageComponent | MessageActionRowComponent | ThumbnailComponent;
-export type AnyModalComponent = ModalComponent | ModalActionRowComponent | ModalLabelComponent | FileUploadComponent;
+export type AnyModalComponent = ModalComponent | ModalActionRowComponent | ModalLabelComponent;
 export type AnyBaseComponent = MessageComponent | ModalComponent;
 export type MessageActionRowComponent = ButtonComponent | SelectMenuComponent;
 export type MessageComponent = MessageActionRow | SectionComponent | TextDisplayComponent | MediaGalleryComponent | SeparatorComponent | FileComponent | ContainerComponent;
 /** @deprecated */
 export type ModalActionRowComponent = TextInput;
-export type ModalLabelComponent = SelectMenuComponent | TextInput;
+/** a child of a label component */
+export type ModalLabelComponent = SelectMenuComponent | TextInput | FileUploadComponent;
 export type ModalComponent = ModalActionRow | ModalLabel | TextDisplayComponent;
 export type ButtonComponent = TextButton | URLButton | PremiumButton;
 export type SelectMenuComponent = StringSelectMenu | UserSelectMenu | RoleSelectMenu | MentionableSelectMenu | ChannelSelectMenu;

--- a/lib/types/channels.d.ts
+++ b/lib/types/channels.d.ts
@@ -1225,7 +1225,7 @@ export type RawMessageActionRowComponent = RawButtonComponent | RawSelectMenuCom
 export type RawMessageComponent = RawMessageActionRow | RawSectionComponent | RawTextDisplayComponent | RawMediaGalleryComponent | RawSeparatorComponent | RawFileComponent | RawContainerComponent;
 /** @deprecated */
 export type RawModalActionRowComponent = RawTextInput;
-export type RawModalLabelComponent = RawSelectMenuComponent | RawTextInput | RawFileUploadComponent;
+export type RawModalLabelComponent = RawSelectMenuComponent | RawTextInput | RawModalFileUploadComponent;
 export type RawModalComponent = RawModalActionRow | RawModalLabel | RawTextDisplayComponent;
 export type RawButtonComponent = RawTextButton | URLButton | RawPremiumButton;
 export type RawSelectMenuComponent = RawStringSelectMenu | RawUserSelectMenu | RawRoleSelectMenu | RawMentionableSelectMenu | RawChannelSelectMenu;
@@ -1249,7 +1249,7 @@ export type ToComponentFromRaw<T extends RawComponent> =
                                                                 T extends RawFileComponent ? FileComponent :
                                                                     T extends RawContainerComponent ? ContainerComponent :
                                                                         T extends RawModalLabel ? ModalLabel :
-                                                                            T extends RawFileUploadComponent ? FileUploadComponent :
+                                                                            T extends RawModalFileUploadComponent ? ModalFileUploadComponent :
                                                                                 never;
 export type ToRawFromComponent<T extends Component> =
     T extends MessageActionRow ? RawMessageActionRow :
@@ -1270,7 +1270,7 @@ export type ToRawFromComponent<T extends Component> =
                                                                 T extends FileComponent ? RawFileComponent :
                                                                     T extends ContainerComponent ? RawContainerComponent :
                                                                         T extends ModalLabel ? RawModalLabel :
-                                                                            T extends FileUploadComponent ? RawFileUploadComponent :
+                                                                            T extends ModalFileUploadComponent ? RawModalFileUploadComponent :
                                                                                 never;
 
 export interface RawActionRowBase<T extends RawComponent> {
@@ -1294,7 +1294,7 @@ export type MessageComponent = MessageActionRow | SectionComponent | TextDisplay
 /** @deprecated */
 export type ModalActionRowComponent = TextInput;
 /** a child of a label component */
-export type ModalLabelComponent = SelectMenuComponent | TextInput | FileUploadComponent;
+export type ModalLabelComponent = SelectMenuComponent | TextInput | ModalFileUploadComponent;
 export type ModalComponent = ModalActionRow | ModalLabel | TextDisplayComponent;
 export type ButtonComponent = TextButton | URLButton | PremiumButton;
 export type SelectMenuComponent = StringSelectMenu | UserSelectMenu | RoleSelectMenu | MentionableSelectMenu | ChannelSelectMenu;
@@ -1512,7 +1512,7 @@ export interface RawModalLabel extends Omit<BaseComponent, "id"> {
     type: ComponentTypes.LABEL;
 }
 
-export interface FileUploadComponent extends BaseComponent {
+export interface ModalFileUploadComponent extends BaseComponent {
     customID: string;
     maxValues?: number;
     minValues?: number;
@@ -1520,7 +1520,7 @@ export interface FileUploadComponent extends BaseComponent {
     type: ComponentTypes.FILE_UPLOAD;
 }
 
-export interface RawFileUploadComponent extends BaseComponent {
+export interface RawModalFileUploadComponent extends BaseComponent {
     custom_id: string;
     max_values?: number;
     min_values?: number;

--- a/lib/types/interactions.d.ts
+++ b/lib/types/interactions.d.ts
@@ -45,8 +45,8 @@ import type Guild from "../structures/Guild";
 import type Permission from "../structures/Permission";
 import type ModalSubmitInteractionComponentsWrapper from "../util/interactions/ModalSubmitInteractionComponentsWrapper";
 
-export interface InteractionContent extends Pick<ExecuteWebhookOptions, "tts" | "content" | "embeds" | "allowedMentions" | "flags" | "components" | "attachments" | "files" | "poll"> { }
-export interface EditInteractionContent extends Pick<EditWebhookMessageOptions, "content" | "embeds" | "allowedMentions" | "flags" | "components" | "attachments" | "files" | "poll"> { }
+export interface InteractionContent extends Pick<ExecuteWebhookOptions, "tts" | "content" | "embeds" | "allowedMentions" | "flags" | "components" | "attachments" | "files" | "poll"> {}
+export interface EditInteractionContent extends Pick<EditWebhookMessageOptions, "content" | "embeds" | "allowedMentions" | "flags" | "components" | "attachments" | "files" | "poll"> {}
 
 export type InteractionResponse = PingInteractionResponse | MessageInteractionResponse | DeferredInteractionResponse | AutocompleteInteractionResponse | ModalSubmitInteractionResponse | PremiumRequiredResponse | LaunchActivityResponse;
 export interface PingInteractionResponse {
@@ -117,11 +117,11 @@ export interface RawInteraction {
     version: 1;
 }
 
-export interface AuthorizingIntegrationOwners extends Partial<Record<`${ApplicationIntegrationTypes}`, string>> { }
+export interface AuthorizingIntegrationOwners extends Partial<Record<`${ApplicationIntegrationTypes}`, string>> {}
 
 export type AnyRawInteraction = RawPingInteraction | AnyRawGatewayInteraction;
 export type AnyRawGatewayInteraction = RawApplicationCommandInteraction | RawMessageComponentInteraction | RawAutocompleteInteraction | RawModalSubmitInteraction;
-export interface RawPingInteraction extends Pick<RawInteraction, "application_id" | "id" | "token" | "type" | "version"> { }
+export interface RawPingInteraction extends Pick<RawInteraction, "application_id" | "id" | "token" | "type" | "version"> {}
 export interface RawApplicationCommandInteraction extends Omit<RawInteraction, "data" | "message"> { data: RawApplicationCommandInteractionData; }
 export interface RawMessageComponentInteraction extends Omit<RawInteraction, "data" | "message"> { data: RawMessageComponentInteractionData; message: RawMessage; }
 export interface RawAutocompleteInteraction extends Omit<RawInteraction, "data" | "message"> { data: RawAutocompleteInteractionData; }
@@ -148,8 +148,8 @@ export interface ApplicationCommandInteractionData<T extends AnyInteractionChann
     targetID: C extends ApplicationCommandTypes.CHAT_INPUT ? null : C extends ApplicationCommandTypes.USER | ApplicationCommandTypes.MESSAGE ? string : string | null;
     type: C;
 }
-export interface RawAutocompleteInteractionData extends Omit<RawApplicationCommandInteractionData, "resolved" | "target_id"> { }
-export interface AutocompleteInteractionData extends Omit<ApplicationCommandInteractionData, "resolved" | "target" | "targetID"> { }
+export interface RawAutocompleteInteractionData extends Omit<RawApplicationCommandInteractionData, "resolved" | "target_id"> {}
+export interface AutocompleteInteractionData extends Omit<ApplicationCommandInteractionData, "resolved" | "target" | "targetID"> {}
 
 export interface RawMessageComponentInteractionResolvedData {
     channels?: Record<string, RawInteractionResolvedChannel>;
@@ -309,27 +309,27 @@ type Privatify<T extends Interaction> = Omit<T, "guild" | "guildID" | "guildLoca
     memberPermissions: undefined;
 };
 
-export interface GuildAutocompleteInteraction extends Guildify<AutocompleteInteraction<AnyTextableGuildChannel>> { }
-export interface PrivateAutocompleteInteraction extends Privatify<AutocompleteInteraction<AnyPrivateChannel | Uncached>> { }
+export interface GuildAutocompleteInteraction extends Guildify<AutocompleteInteraction<AnyTextableGuildChannel>> {}
+export interface PrivateAutocompleteInteraction extends Privatify<AutocompleteInteraction<AnyPrivateChannel | Uncached>> {}
 export type AnyAutocompleteInteraction = GuildAutocompleteInteraction | PrivateAutocompleteInteraction;
 
-export interface GuildCommandInteraction extends Guildify<CommandInteraction<AnyTextableGuildChannel>> { }
-export interface PrivateCommandInteraction extends Privatify<CommandInteraction<AnyPrivateChannel | Uncached>> { }
+export interface GuildCommandInteraction extends Guildify<CommandInteraction<AnyTextableGuildChannel>> {}
+export interface PrivateCommandInteraction extends Privatify<CommandInteraction<AnyPrivateChannel | Uncached>> {}
 export type AnyCommandInteraction = GuildCommandInteraction | PrivateCommandInteraction;
 
-export interface GuildComponentButtonInteraction extends Guildify<ComponentInteraction<ComponentTypes.BUTTON, AnyTextableGuildChannel>> { }
-export interface GuildComponentSelectMenuInteraction extends Guildify<ComponentInteraction<SelectMenuTypes, AnyTextableGuildChannel>> { }
+export interface GuildComponentButtonInteraction extends Guildify<ComponentInteraction<ComponentTypes.BUTTON, AnyTextableGuildChannel>> {}
+export interface GuildComponentSelectMenuInteraction extends Guildify<ComponentInteraction<SelectMenuTypes, AnyTextableGuildChannel>> {}
 export type GuildComponentInteraction = GuildComponentButtonInteraction | GuildComponentSelectMenuInteraction;
 
-export interface PrivateComponentButtonInteraction extends Privatify<ComponentInteraction<ComponentTypes.BUTTON, AnyPrivateChannel | Uncached>> { }
-export interface PrivateComponentSelectMenuInteraction extends Privatify<ComponentInteraction<SelectMenuTypes, AnyPrivateChannel | Uncached>> { }
+export interface PrivateComponentButtonInteraction extends Privatify<ComponentInteraction<ComponentTypes.BUTTON, AnyPrivateChannel | Uncached>> {}
+export interface PrivateComponentSelectMenuInteraction extends Privatify<ComponentInteraction<SelectMenuTypes, AnyPrivateChannel | Uncached>> {}
 export type PrivateComponentInteraction = PrivateComponentButtonInteraction | PrivateComponentSelectMenuInteraction;
 export type AnyComponentButtonInteraction = GuildComponentButtonInteraction | PrivateComponentButtonInteraction;
 export type AnyComponentSelectMenuInteraction = GuildComponentSelectMenuInteraction | PrivateComponentSelectMenuInteraction;
 export type AnyComponentInteraction = AnyComponentButtonInteraction | AnyComponentSelectMenuInteraction;
 
-export interface GuildModalSubmitInteraction extends Guildify<ModalSubmitInteraction<AnyTextableGuildChannel>> { }
-export interface PrivateModalSubmitInteraction extends Privatify<ModalSubmitInteraction<AnyPrivateChannel | Uncached>> { }
+export interface GuildModalSubmitInteraction extends Guildify<ModalSubmitInteraction<AnyTextableGuildChannel>> {}
+export interface PrivateModalSubmitInteraction extends Privatify<ModalSubmitInteraction<AnyPrivateChannel | Uncached>> {}
 export type AnyModalSubmitInteraction = GuildModalSubmitInteraction | PrivateModalSubmitInteraction;
 
 export type SubCommandArray = [subcommand: string] | [subcommandGroup: string, subcommand: string];
@@ -388,26 +388,26 @@ interface ModalComponentsLabel<T extends ModalSubmitComponents> {
 }
 
 export type ToModalSubmitComponentFromRaw<T extends RawModalSubmitComponents> =
-    T extends RawModalSubmitTextInputComponent ? ModalSubmitTextInputComponent :
-        T extends RawModalSubmitStringSelectComponent ? ModalSubmitStringSelectComponent :
-            T extends RawModalSubmitUserSelectComponent ? ModalSubmitUserSelectComponent :
-                T extends RawModalSubmitRoleSelectComponent ? ModalSubmitRoleSelectComponent :
-                    T extends RawModalSubmitMentionableSelectComponent ? ModalSubmitMentionableSelectComponent :
-                        T extends RawModalSubmitChannelSelectComponent ? ModalSubmitChannelSelectComponent :
-                            T extends RawModalSubmitFileUploadComponent ? ModalSubmitFileUploadComponent :
-                                never;
+T extends RawModalSubmitTextInputComponent ? ModalSubmitTextInputComponent :
+    T extends RawModalSubmitStringSelectComponent ? ModalSubmitStringSelectComponent :
+        T extends RawModalSubmitUserSelectComponent ? ModalSubmitUserSelectComponent :
+            T extends RawModalSubmitRoleSelectComponent ? ModalSubmitRoleSelectComponent :
+                T extends RawModalSubmitMentionableSelectComponent ? ModalSubmitMentionableSelectComponent :
+                    T extends RawModalSubmitChannelSelectComponent ? ModalSubmitChannelSelectComponent :
+                        T extends RawModalSubmitFileUploadComponent ? ModalSubmitFileUploadComponent :
+                            never;
 
 /** @deprecated */
 export type RawModalSubmitComponentsActionRow = RawModalComponentsActionRow<RawModalSubmitComponents>;
 export type RawModalSubmitComponentsLabel = RawModalComponentsLabel<RawModalSubmitComponents>;
 export type RawModalSubmitComponents = RawModalSubmitTextInputComponent | RawModalSubmitFileUploadComponent | RawModalSubmitSelectComponents;
 export type RawModalSubmitSelectComponents = RawModalSubmitStringSelectComponent | RawModalSubmitUserSelectComponent | RawModalSubmitRoleSelectComponent | RawModalSubmitMentionableSelectComponent | RawModalSubmitChannelSelectComponent;
-export interface RawModalSubmitTextInputComponent extends RawModalSubmitComponentsStringValue<ComponentTypes.TEXT_INPUT> { }
-export interface RawModalSubmitStringSelectComponent extends RawModalSubmitComponentsStringValues<ComponentTypes.STRING_SELECT> { }
-export interface RawModalSubmitUserSelectComponent extends RawModalSubmitComponentsStringValues<ComponentTypes.USER_SELECT> { }
-export interface RawModalSubmitRoleSelectComponent extends RawModalSubmitComponentsStringValues<ComponentTypes.ROLE_SELECT> { }
-export interface RawModalSubmitMentionableSelectComponent extends RawModalSubmitComponentsStringValues<ComponentTypes.MENTIONABLE_SELECT> { }
-export interface RawModalSubmitChannelSelectComponent extends RawModalSubmitComponentsStringValues<ComponentTypes.CHANNEL_SELECT> { }
+export interface RawModalSubmitTextInputComponent extends RawModalSubmitComponentsStringValue<ComponentTypes.TEXT_INPUT> {}
+export interface RawModalSubmitStringSelectComponent extends RawModalSubmitComponentsStringValues<ComponentTypes.STRING_SELECT> {}
+export interface RawModalSubmitUserSelectComponent extends RawModalSubmitComponentsStringValues<ComponentTypes.USER_SELECT> {}
+export interface RawModalSubmitRoleSelectComponent extends RawModalSubmitComponentsStringValues<ComponentTypes.ROLE_SELECT> {}
+export interface RawModalSubmitMentionableSelectComponent extends RawModalSubmitComponentsStringValues<ComponentTypes.MENTIONABLE_SELECT> {}
+export interface RawModalSubmitChannelSelectComponent extends RawModalSubmitComponentsStringValues<ComponentTypes.CHANNEL_SELECT> {}
 export interface RawModalSubmitFileUploadComponent extends RawModalSubmitComponentsStringValues<ComponentTypes.FILE_UPLOAD> { }
 
 interface ModalSubmitComponentsBase {
@@ -425,25 +425,26 @@ export interface ModalSubmitComponentsStringValues<T extends ModalComponentTypes
 }
 
 export type ToRawFromoModalSubmitComponent<T extends ModalSubmitComponents> =
-    T extends ModalSubmitTextInputComponent ? RawModalSubmitTextInputComponent :
-        T extends ModalSubmitStringSelectComponent ? RawModalSubmitStringSelectComponent :
-            T extends ModalSubmitUserSelectComponent ? RawModalSubmitUserSelectComponent :
-                T extends ModalSubmitRoleSelectComponent ? RawModalSubmitRoleSelectComponent :
-                    T extends ModalSubmitMentionableSelectComponent ? RawModalSubmitMentionableSelectComponent :
-                        T extends ModalSubmitChannelSelectComponent ? RawModalSubmitChannelSelectComponent :
+T extends ModalSubmitTextInputComponent ? RawModalSubmitTextInputComponent :
+    T extends ModalSubmitStringSelectComponent ? RawModalSubmitStringSelectComponent :
+        T extends ModalSubmitUserSelectComponent ? RawModalSubmitUserSelectComponent :
+            T extends ModalSubmitRoleSelectComponent ? RawModalSubmitRoleSelectComponent :
+                T extends ModalSubmitMentionableSelectComponent ? RawModalSubmitMentionableSelectComponent :
+                    T extends ModalSubmitChannelSelectComponent ? RawModalSubmitChannelSelectComponent :
+                        T extends ModalSubmitFileUploadComponent ? RawModalSubmitFileUploadComponent :
                             never;
 
 /** @deprecated */
 export type ModalSubmitComponentsActionRow = ModalComponentsActionRow<ModalSubmitComponents>;
 export type ModalSubmitComponentsLabel = ModalComponentsLabel<ModalSubmitComponents>;
 export type ModalSubmitComponents = ModalSubmitTextInputComponent | ModalSubmitSelectComponents;
-export type ModalSubmitSelectComponents = ModalSubmitStringSelectComponent | ModalSubmitUserSelectComponent | ModalSubmitRoleSelectComponent | ModalSubmitMentionableSelectComponent | ModalSubmitChannelSelectComponent | ModalSubmitFileUploadComponent;
-export interface ModalSubmitTextInputComponent extends ModalSubmitComponentsStringValue<ComponentTypes.TEXT_INPUT> { }
-export interface ModalSubmitStringSelectComponent extends ModalSubmitComponentsStringValues<ComponentTypes.STRING_SELECT> { }
-export interface ModalSubmitUserSelectComponent extends ModalSubmitComponentsStringValues<ComponentTypes.USER_SELECT> { }
-export interface ModalSubmitRoleSelectComponent extends ModalSubmitComponentsStringValues<ComponentTypes.ROLE_SELECT> { }
-export interface ModalSubmitMentionableSelectComponent extends ModalSubmitComponentsStringValues<ComponentTypes.MENTIONABLE_SELECT> { }
-export interface ModalSubmitChannelSelectComponent extends ModalSubmitComponentsStringValues<ComponentTypes.CHANNEL_SELECT> { }
+export type ModalSubmitSelectComponents = ModalSubmitStringSelectComponent | ModalSubmitUserSelectComponent | ModalSubmitRoleSelectComponent | ModalSubmitMentionableSelectComponent | ModalSubmitChannelSelectComponent;
+export interface ModalSubmitTextInputComponent extends ModalSubmitComponentsStringValue<ComponentTypes.TEXT_INPUT> {}
+export interface ModalSubmitStringSelectComponent extends ModalSubmitComponentsStringValues<ComponentTypes.STRING_SELECT> {}
+export interface ModalSubmitUserSelectComponent extends ModalSubmitComponentsStringValues<ComponentTypes.USER_SELECT> {}
+export interface ModalSubmitRoleSelectComponent extends ModalSubmitComponentsStringValues<ComponentTypes.ROLE_SELECT> {}
+export interface ModalSubmitMentionableSelectComponent extends ModalSubmitComponentsStringValues<ComponentTypes.MENTIONABLE_SELECT> {}
+export interface ModalSubmitChannelSelectComponent extends ModalSubmitComponentsStringValues<ComponentTypes.CHANNEL_SELECT> {}
 export interface ModalSubmitFileUploadComponent extends ModalSubmitComponentsStringValues<ComponentTypes.FILE_UPLOAD> { }
 
 export type ApplicationCommandTypesWithTarget = ApplicationCommandTypes.USER | ApplicationCommandTypes.MESSAGE;

--- a/lib/types/interactions.d.ts
+++ b/lib/types/interactions.d.ts
@@ -152,7 +152,6 @@ export interface RawAutocompleteInteractionData extends Omit<RawApplicationComma
 export interface AutocompleteInteractionData extends Omit<ApplicationCommandInteractionData, "resolved" | "target" | "targetID"> { }
 
 export interface RawMessageComponentInteractionResolvedData {
-    attachments?: Record<string, RawAttachment>;
     channels?: Record<string, RawInteractionResolvedChannel>;
     members?: Record<string, Omit<RawMember, "user" | "deaf" | "mute">>;
     roles?: Record<string, RawRole>;
@@ -160,7 +159,6 @@ export interface RawMessageComponentInteractionResolvedData {
 }
 
 export interface MessageComponentInteractionResolvedData {
-    attachments: TypedCollection<RawAttachment, Attachment>;
     channels: TypedCollection<RawInteractionResolvedChannel, InteractionResolvedChannel>;
     members: TypedCollection<RawMember, Member, [guildID: string]>;
     roles: TypedCollection<RawRole, Role, [guildID: string]>;

--- a/lib/types/interactions.d.ts
+++ b/lib/types/interactions.d.ts
@@ -437,7 +437,7 @@ T extends ModalSubmitTextInputComponent ? RawModalSubmitTextInputComponent :
 /** @deprecated */
 export type ModalSubmitComponentsActionRow = ModalComponentsActionRow<ModalSubmitComponents>;
 export type ModalSubmitComponentsLabel = ModalComponentsLabel<ModalSubmitComponents>;
-export type ModalSubmitComponents = ModalSubmitTextInputComponent | ModalSubmitSelectComponents;
+export type ModalSubmitComponents = ModalSubmitTextInputComponent | ModalSubmitSelectComponents | ModalSubmitFileUploadComponent;
 export type ModalSubmitSelectComponents = ModalSubmitStringSelectComponent | ModalSubmitUserSelectComponent | ModalSubmitRoleSelectComponent | ModalSubmitMentionableSelectComponent | ModalSubmitChannelSelectComponent;
 export interface ModalSubmitTextInputComponent extends ModalSubmitComponentsStringValue<ComponentTypes.TEXT_INPUT> {}
 export interface ModalSubmitStringSelectComponent extends ModalSubmitComponentsStringValues<ComponentTypes.STRING_SELECT> {}

--- a/lib/types/interactions.d.ts
+++ b/lib/types/interactions.d.ts
@@ -45,8 +45,8 @@ import type Guild from "../structures/Guild";
 import type Permission from "../structures/Permission";
 import type ModalSubmitInteractionComponentsWrapper from "../util/interactions/ModalSubmitInteractionComponentsWrapper";
 
-export interface InteractionContent extends Pick<ExecuteWebhookOptions, "tts" | "content" | "embeds" | "allowedMentions" | "flags" | "components" | "attachments" | "files" | "poll"> {}
-export interface EditInteractionContent extends Pick<EditWebhookMessageOptions, "content" | "embeds" | "allowedMentions" | "flags" | "components" | "attachments" | "files" | "poll"> {}
+export interface InteractionContent extends Pick<ExecuteWebhookOptions, "tts" | "content" | "embeds" | "allowedMentions" | "flags" | "components" | "attachments" | "files" | "poll"> { }
+export interface EditInteractionContent extends Pick<EditWebhookMessageOptions, "content" | "embeds" | "allowedMentions" | "flags" | "components" | "attachments" | "files" | "poll"> { }
 
 export type InteractionResponse = PingInteractionResponse | MessageInteractionResponse | DeferredInteractionResponse | AutocompleteInteractionResponse | ModalSubmitInteractionResponse | PremiumRequiredResponse | LaunchActivityResponse;
 export interface PingInteractionResponse {
@@ -117,11 +117,11 @@ export interface RawInteraction {
     version: 1;
 }
 
-export interface AuthorizingIntegrationOwners extends Partial<Record<`${ApplicationIntegrationTypes}`, string>> {}
+export interface AuthorizingIntegrationOwners extends Partial<Record<`${ApplicationIntegrationTypes}`, string>> { }
 
 export type AnyRawInteraction = RawPingInteraction | AnyRawGatewayInteraction;
 export type AnyRawGatewayInteraction = RawApplicationCommandInteraction | RawMessageComponentInteraction | RawAutocompleteInteraction | RawModalSubmitInteraction;
-export interface RawPingInteraction extends Pick<RawInteraction, "application_id" | "id" | "token" | "type" | "version"> {}
+export interface RawPingInteraction extends Pick<RawInteraction, "application_id" | "id" | "token" | "type" | "version"> { }
 export interface RawApplicationCommandInteraction extends Omit<RawInteraction, "data" | "message"> { data: RawApplicationCommandInteractionData; }
 export interface RawMessageComponentInteraction extends Omit<RawInteraction, "data" | "message"> { data: RawMessageComponentInteractionData; message: RawMessage; }
 export interface RawAutocompleteInteraction extends Omit<RawInteraction, "data" | "message"> { data: RawAutocompleteInteractionData; }
@@ -148,10 +148,11 @@ export interface ApplicationCommandInteractionData<T extends AnyInteractionChann
     targetID: C extends ApplicationCommandTypes.CHAT_INPUT ? null : C extends ApplicationCommandTypes.USER | ApplicationCommandTypes.MESSAGE ? string : string | null;
     type: C;
 }
-export interface RawAutocompleteInteractionData extends Omit<RawApplicationCommandInteractionData, "resolved" | "target_id"> {}
-export interface AutocompleteInteractionData extends Omit<ApplicationCommandInteractionData, "resolved" | "target" | "targetID"> {}
+export interface RawAutocompleteInteractionData extends Omit<RawApplicationCommandInteractionData, "resolved" | "target_id"> { }
+export interface AutocompleteInteractionData extends Omit<ApplicationCommandInteractionData, "resolved" | "target" | "targetID"> { }
 
 export interface RawMessageComponentInteractionResolvedData {
+    attachments?: Record<string, RawAttachment>;
     channels?: Record<string, RawInteractionResolvedChannel>;
     members?: Record<string, Omit<RawMember, "user" | "deaf" | "mute">>;
     roles?: Record<string, RawRole>;
@@ -159,6 +160,7 @@ export interface RawMessageComponentInteractionResolvedData {
 }
 
 export interface MessageComponentInteractionResolvedData {
+    attachments: TypedCollection<RawAttachment, Attachment>;
     channels: TypedCollection<RawInteractionResolvedChannel, InteractionResolvedChannel>;
     members: TypedCollection<RawMember, Member, [guildID: string]>;
     roles: TypedCollection<RawRole, Role, [guildID: string]>;
@@ -186,6 +188,7 @@ export interface MessageComponentSelectMenuInteractionData {
 }
 
 export interface RawModalSubmitInteractionResolvedData {
+    attachments?: Record<string, RawAttachment>;
     channels?: Record<string, RawInteractionResolvedChannel>;
     members?: Record<string, Omit<RawMember, "user" | "deaf" | "mute">>;
     roles?: Record<string, RawRole>;
@@ -193,6 +196,7 @@ export interface RawModalSubmitInteractionResolvedData {
 }
 
 export interface ModalSubmitInteractionResolvedData {
+    attachments: TypedCollection<RawAttachment, Attachment>;
     channels: TypedCollection<RawInteractionResolvedChannel, InteractionResolvedChannel>;
     members: TypedCollection<RawMember, Member, [guildID: string]>;
     roles: TypedCollection<RawRole, Role, [guildID: string]>;
@@ -307,27 +311,27 @@ type Privatify<T extends Interaction> = Omit<T, "guild" | "guildID" | "guildLoca
     memberPermissions: undefined;
 };
 
-export interface GuildAutocompleteInteraction extends Guildify<AutocompleteInteraction<AnyTextableGuildChannel>> {}
-export interface PrivateAutocompleteInteraction extends Privatify<AutocompleteInteraction<AnyPrivateChannel | Uncached>> {}
+export interface GuildAutocompleteInteraction extends Guildify<AutocompleteInteraction<AnyTextableGuildChannel>> { }
+export interface PrivateAutocompleteInteraction extends Privatify<AutocompleteInteraction<AnyPrivateChannel | Uncached>> { }
 export type AnyAutocompleteInteraction = GuildAutocompleteInteraction | PrivateAutocompleteInteraction;
 
-export interface GuildCommandInteraction extends Guildify<CommandInteraction<AnyTextableGuildChannel>> {}
-export interface PrivateCommandInteraction extends Privatify<CommandInteraction<AnyPrivateChannel | Uncached>> {}
+export interface GuildCommandInteraction extends Guildify<CommandInteraction<AnyTextableGuildChannel>> { }
+export interface PrivateCommandInteraction extends Privatify<CommandInteraction<AnyPrivateChannel | Uncached>> { }
 export type AnyCommandInteraction = GuildCommandInteraction | PrivateCommandInteraction;
 
-export interface GuildComponentButtonInteraction extends Guildify<ComponentInteraction<ComponentTypes.BUTTON, AnyTextableGuildChannel>> {}
-export interface GuildComponentSelectMenuInteraction extends Guildify<ComponentInteraction<SelectMenuTypes, AnyTextableGuildChannel>> {}
+export interface GuildComponentButtonInteraction extends Guildify<ComponentInteraction<ComponentTypes.BUTTON, AnyTextableGuildChannel>> { }
+export interface GuildComponentSelectMenuInteraction extends Guildify<ComponentInteraction<SelectMenuTypes, AnyTextableGuildChannel>> { }
 export type GuildComponentInteraction = GuildComponentButtonInteraction | GuildComponentSelectMenuInteraction;
 
-export interface PrivateComponentButtonInteraction extends Privatify<ComponentInteraction<ComponentTypes.BUTTON, AnyPrivateChannel | Uncached>> {}
-export interface PrivateComponentSelectMenuInteraction extends Privatify<ComponentInteraction<SelectMenuTypes, AnyPrivateChannel | Uncached>> {}
+export interface PrivateComponentButtonInteraction extends Privatify<ComponentInteraction<ComponentTypes.BUTTON, AnyPrivateChannel | Uncached>> { }
+export interface PrivateComponentSelectMenuInteraction extends Privatify<ComponentInteraction<SelectMenuTypes, AnyPrivateChannel | Uncached>> { }
 export type PrivateComponentInteraction = PrivateComponentButtonInteraction | PrivateComponentSelectMenuInteraction;
 export type AnyComponentButtonInteraction = GuildComponentButtonInteraction | PrivateComponentButtonInteraction;
 export type AnyComponentSelectMenuInteraction = GuildComponentSelectMenuInteraction | PrivateComponentSelectMenuInteraction;
 export type AnyComponentInteraction = AnyComponentButtonInteraction | AnyComponentSelectMenuInteraction;
 
-export interface GuildModalSubmitInteraction extends Guildify<ModalSubmitInteraction<AnyTextableGuildChannel>> {}
-export interface PrivateModalSubmitInteraction extends Privatify<ModalSubmitInteraction<AnyPrivateChannel | Uncached>> {}
+export interface GuildModalSubmitInteraction extends Guildify<ModalSubmitInteraction<AnyTextableGuildChannel>> { }
+export interface PrivateModalSubmitInteraction extends Privatify<ModalSubmitInteraction<AnyPrivateChannel | Uncached>> { }
 export type AnyModalSubmitInteraction = GuildModalSubmitInteraction | PrivateModalSubmitInteraction;
 
 export type SubCommandArray = [subcommand: string] | [subcommandGroup: string, subcommand: string];
@@ -386,25 +390,27 @@ interface ModalComponentsLabel<T extends ModalSubmitComponents> {
 }
 
 export type ToModalSubmitComponentFromRaw<T extends RawModalSubmitComponents> =
-T extends RawModalSubmitTextInputComponent ? ModalSubmitTextInputComponent :
-    T extends RawModalSubmitStringSelectComponent ? ModalSubmitStringSelectComponent :
-        T extends RawModalSubmitUserSelectComponent ? ModalSubmitUserSelectComponent :
-            T extends RawModalSubmitRoleSelectComponent ? ModalSubmitRoleSelectComponent :
-                T extends RawModalSubmitMentionableSelectComponent ? ModalSubmitMentionableSelectComponent :
-                    T extends RawModalSubmitChannelSelectComponent ? ModalSubmitChannelSelectComponent :
-                        never;
+    T extends RawModalSubmitTextInputComponent ? ModalSubmitTextInputComponent :
+        T extends RawModalSubmitStringSelectComponent ? ModalSubmitStringSelectComponent :
+            T extends RawModalSubmitUserSelectComponent ? ModalSubmitUserSelectComponent :
+                T extends RawModalSubmitRoleSelectComponent ? ModalSubmitRoleSelectComponent :
+                    T extends RawModalSubmitMentionableSelectComponent ? ModalSubmitMentionableSelectComponent :
+                        T extends RawModalSubmitChannelSelectComponent ? ModalSubmitChannelSelectComponent :
+                            T extends RawModalSubmitFileUploadComponent ? ModalSubmitFileUploadComponent :
+                                never;
 
 /** @deprecated */
 export type RawModalSubmitComponentsActionRow = RawModalComponentsActionRow<RawModalSubmitComponents>;
 export type RawModalSubmitComponentsLabel = RawModalComponentsLabel<RawModalSubmitComponents>;
-export type RawModalSubmitComponents = RawModalSubmitTextInputComponent | RawModalSubmitSelectComponents;
+export type RawModalSubmitComponents = RawModalSubmitTextInputComponent | RawModalSubmitFileUploadComponent | RawModalSubmitSelectComponents;
 export type RawModalSubmitSelectComponents = RawModalSubmitStringSelectComponent | RawModalSubmitUserSelectComponent | RawModalSubmitRoleSelectComponent | RawModalSubmitMentionableSelectComponent | RawModalSubmitChannelSelectComponent;
-export interface RawModalSubmitTextInputComponent extends RawModalSubmitComponentsStringValue<ComponentTypes.TEXT_INPUT> {}
-export interface RawModalSubmitStringSelectComponent extends RawModalSubmitComponentsStringValues<ComponentTypes.STRING_SELECT> {}
-export interface RawModalSubmitUserSelectComponent extends RawModalSubmitComponentsStringValues<ComponentTypes.USER_SELECT> {}
-export interface RawModalSubmitRoleSelectComponent extends RawModalSubmitComponentsStringValues<ComponentTypes.ROLE_SELECT> {}
-export interface RawModalSubmitMentionableSelectComponent extends RawModalSubmitComponentsStringValues<ComponentTypes.MENTIONABLE_SELECT> {}
-export interface RawModalSubmitChannelSelectComponent extends RawModalSubmitComponentsStringValues<ComponentTypes.CHANNEL_SELECT> {}
+export interface RawModalSubmitTextInputComponent extends RawModalSubmitComponentsStringValue<ComponentTypes.TEXT_INPUT> { }
+export interface RawModalSubmitStringSelectComponent extends RawModalSubmitComponentsStringValues<ComponentTypes.STRING_SELECT> { }
+export interface RawModalSubmitUserSelectComponent extends RawModalSubmitComponentsStringValues<ComponentTypes.USER_SELECT> { }
+export interface RawModalSubmitRoleSelectComponent extends RawModalSubmitComponentsStringValues<ComponentTypes.ROLE_SELECT> { }
+export interface RawModalSubmitMentionableSelectComponent extends RawModalSubmitComponentsStringValues<ComponentTypes.MENTIONABLE_SELECT> { }
+export interface RawModalSubmitChannelSelectComponent extends RawModalSubmitComponentsStringValues<ComponentTypes.CHANNEL_SELECT> { }
+export interface RawModalSubmitFileUploadComponent extends RawModalSubmitComponentsStringValues<ComponentTypes.FILE_UPLOAD> { }
 
 interface ModalSubmitComponentsBase {
     customID: string;
@@ -421,25 +427,26 @@ export interface ModalSubmitComponentsStringValues<T extends ModalComponentTypes
 }
 
 export type ToRawFromoModalSubmitComponent<T extends ModalSubmitComponents> =
-T extends ModalSubmitTextInputComponent ? RawModalSubmitTextInputComponent :
-    T extends ModalSubmitStringSelectComponent ? RawModalSubmitStringSelectComponent :
-        T extends ModalSubmitUserSelectComponent ? RawModalSubmitUserSelectComponent :
-            T extends ModalSubmitRoleSelectComponent ? RawModalSubmitRoleSelectComponent :
-                T extends ModalSubmitMentionableSelectComponent ? RawModalSubmitMentionableSelectComponent :
-                    T extends ModalSubmitChannelSelectComponent ? RawModalSubmitChannelSelectComponent :
-                        never;
+    T extends ModalSubmitTextInputComponent ? RawModalSubmitTextInputComponent :
+        T extends ModalSubmitStringSelectComponent ? RawModalSubmitStringSelectComponent :
+            T extends ModalSubmitUserSelectComponent ? RawModalSubmitUserSelectComponent :
+                T extends ModalSubmitRoleSelectComponent ? RawModalSubmitRoleSelectComponent :
+                    T extends ModalSubmitMentionableSelectComponent ? RawModalSubmitMentionableSelectComponent :
+                        T extends ModalSubmitChannelSelectComponent ? RawModalSubmitChannelSelectComponent :
+                            never;
 
 /** @deprecated */
 export type ModalSubmitComponentsActionRow = ModalComponentsActionRow<ModalSubmitComponents>;
 export type ModalSubmitComponentsLabel = ModalComponentsLabel<ModalSubmitComponents>;
 export type ModalSubmitComponents = ModalSubmitTextInputComponent | ModalSubmitSelectComponents;
-export type ModalSubmitSelectComponents = ModalSubmitStringSelectComponent | ModalSubmitUserSelectComponent | ModalSubmitRoleSelectComponent | ModalSubmitMentionableSelectComponent | ModalSubmitChannelSelectComponent;
-export interface ModalSubmitTextInputComponent extends ModalSubmitComponentsStringValue<ComponentTypes.TEXT_INPUT> {}
-export interface ModalSubmitStringSelectComponent extends ModalSubmitComponentsStringValues<ComponentTypes.STRING_SELECT> {}
-export interface ModalSubmitUserSelectComponent extends ModalSubmitComponentsStringValues<ComponentTypes.USER_SELECT> {}
-export interface ModalSubmitRoleSelectComponent extends ModalSubmitComponentsStringValues<ComponentTypes.ROLE_SELECT> {}
-export interface ModalSubmitMentionableSelectComponent extends ModalSubmitComponentsStringValues<ComponentTypes.MENTIONABLE_SELECT> {}
-export interface ModalSubmitChannelSelectComponent extends ModalSubmitComponentsStringValues<ComponentTypes.CHANNEL_SELECT> {}
+export type ModalSubmitSelectComponents = ModalSubmitStringSelectComponent | ModalSubmitUserSelectComponent | ModalSubmitRoleSelectComponent | ModalSubmitMentionableSelectComponent | ModalSubmitChannelSelectComponent | ModalSubmitFileUploadComponent;
+export interface ModalSubmitTextInputComponent extends ModalSubmitComponentsStringValue<ComponentTypes.TEXT_INPUT> { }
+export interface ModalSubmitStringSelectComponent extends ModalSubmitComponentsStringValues<ComponentTypes.STRING_SELECT> { }
+export interface ModalSubmitUserSelectComponent extends ModalSubmitComponentsStringValues<ComponentTypes.USER_SELECT> { }
+export interface ModalSubmitRoleSelectComponent extends ModalSubmitComponentsStringValues<ComponentTypes.ROLE_SELECT> { }
+export interface ModalSubmitMentionableSelectComponent extends ModalSubmitComponentsStringValues<ComponentTypes.MENTIONABLE_SELECT> { }
+export interface ModalSubmitChannelSelectComponent extends ModalSubmitComponentsStringValues<ComponentTypes.CHANNEL_SELECT> { }
+export interface ModalSubmitFileUploadComponent extends ModalSubmitComponentsStringValues<ComponentTypes.FILE_UPLOAD> { }
 
 export type ApplicationCommandTypesWithTarget = ApplicationCommandTypes.USER | ApplicationCommandTypes.MESSAGE;
 

--- a/lib/util/Util.ts
+++ b/lib/util/Util.ts
@@ -270,6 +270,15 @@ export default class Util {
                     component:   this.componentToParsed(component.component)
                 } as never;
             }
+            case ComponentTypes.FILE_UPLOAD: {
+                return {
+                    customID:  component.custom_id,
+                    maxValues: component.max_values,
+                    minValues: component.min_values,
+                    required:  component.required,
+                    type:      component.type
+                } as never;
+            }
             default: {
                 return component as never;
             }
@@ -380,6 +389,14 @@ export default class Util {
                     component:   this.componentToRaw(component.component)
                 } as never;
             }
+            case ComponentTypes.FILE_UPLOAD:
+                return {
+                    custom_id:  component.customID,
+                    max_values: component.maxValues,
+                    min_values: component.minValues,
+                    required:   component.required,
+                    type:       component.type
+                } as never;
             default: {
                 return component as never;
             }
@@ -637,7 +654,8 @@ export default class Util {
             case ComponentTypes.USER_SELECT:
             case ComponentTypes.ROLE_SELECT:
             case ComponentTypes.MENTIONABLE_SELECT:
-            case ComponentTypes.CHANNEL_SELECT: {
+            case ComponentTypes.CHANNEL_SELECT:
+            case ComponentTypes.FILE_UPLOAD: {
                 return {
                     customID: component.custom_id,
                     type:     component.type,

--- a/lib/util/interactions/ModalSubmitInteractionComponentsWrapper.ts
+++ b/lib/util/interactions/ModalSubmitInteractionComponentsWrapper.ts
@@ -68,12 +68,22 @@ export default class ModalSubmitInteractionComponentsWrapper {
         return this.raw.flatMap(r => r.type === ComponentTypes.ACTION_ROW ? r.components : r.component).filter(Boolean);
     }
 
+    /**
+     * Get a file upload option.
+     * @param name The name of the option.
+     * @param required If true, an error will be thrown if the option is not present.
+     */
     getFileUploadComponent(name: string, required?: false): ModalSubmitFileUploadComponent | undefined;
     getFileUploadComponent(name: string, required: true): ModalSubmitFileUploadComponent;
     getFileUploadComponent(name: string, required?: boolean): ModalSubmitFileUploadComponent | undefined {
         return this._getComponent(name, required, ComponentTypes.FILE_UPLOAD);
     }
 
+    /**
+     * Get the values of a file upload option.
+     * @param name The name of the option.
+     * @param required If true, an error will be thrown if the option is not present.
+     */
     getFileUploadValues(name: string, required?: false): Array<Attachment> | undefined;
     getFileUploadValues(name: string, required: true): Array<Attachment>;
     getFileUploadValues(name: string, required?: boolean): Array<Attachment> | undefined {

--- a/lib/util/interactions/ModalSubmitInteractionComponentsWrapper.ts
+++ b/lib/util/interactions/ModalSubmitInteractionComponentsWrapper.ts
@@ -3,12 +3,12 @@ import { mapRawToResolved } from "./shared";
 import { WrapperError } from "../Errors";
 import { ComponentTypes, type ModalComponentTypes } from "../../Constants";
 import type {
-    MessageComponentInteractionResolvedData,
     ModalSubmitChannelSelectComponent,
     ModalSubmitComponents,
     ModalSubmitComponentsActionRow,
     ModalSubmitComponentsLabel,
     ModalSubmitFileUploadComponent,
+    ModalSubmitInteractionResolvedData,
     ModalSubmitMentionableSelectComponent,
     ModalSubmitRoleSelectComponent,
     ModalSubmitStringSelectComponent,
@@ -25,8 +25,8 @@ import type Attachment from "../../structures/Attachment";
 export default class ModalSubmitInteractionComponentsWrapper {
     /** The raw components from Discord.  */
     raw: Array<ModalSubmitComponentsActionRow | ModalSubmitComponentsLabel>;
-    resolved: MessageComponentInteractionResolvedData;
-    constructor(resolved: MessageComponentInteractionResolvedData, data: Array<ModalSubmitComponentsActionRow | ModalSubmitComponentsLabel>) {
+    resolved: ModalSubmitInteractionResolvedData;
+    constructor(resolved: ModalSubmitInteractionResolvedData, data: Array<ModalSubmitComponentsActionRow | ModalSubmitComponentsLabel>) {
         this.raw = data;
         this.resolved = resolved;
     }

--- a/lib/util/interactions/ModalSubmitInteractionComponentsWrapper.ts
+++ b/lib/util/interactions/ModalSubmitInteractionComponentsWrapper.ts
@@ -8,6 +8,7 @@ import type {
     ModalSubmitComponents,
     ModalSubmitComponentsActionRow,
     ModalSubmitComponentsLabel,
+    ModalSubmitFileUploadComponent,
     ModalSubmitMentionableSelectComponent,
     ModalSubmitRoleSelectComponent,
     ModalSubmitStringSelectComponent,
@@ -18,6 +19,7 @@ import type Role from "../../structures/Role";
 import type User from "../../structures/User";
 import Collection from "../Collection";
 import type InteractionResolvedChannel from "../../structures/InteractionResolvedChannel";
+import type Attachment from "../../structures/Attachment";
 
 /** A wrapper for interaction components. */
 export default class ModalSubmitInteractionComponentsWrapper {
@@ -64,6 +66,19 @@ export default class ModalSubmitInteractionComponentsWrapper {
     /** Get the components in this interaction. */
     getComponents(): Array<ModalSubmitComponents> {
         return this.raw.flatMap(r => r.type === ComponentTypes.ACTION_ROW ? r.components : r.component).filter(Boolean);
+    }
+
+    getFileUploadComponent(name: string, required?: false): ModalSubmitFileUploadComponent | undefined;
+    getFileUploadComponent(name: string, required: true): ModalSubmitFileUploadComponent;
+    getFileUploadComponent(name: string, required?: boolean): ModalSubmitFileUploadComponent | undefined {
+        return this._getComponent(name, required, ComponentTypes.FILE_UPLOAD);
+    }
+
+    getFileUploadValues(name: string, required?: false): Array<Attachment> | undefined;
+    getFileUploadValues(name: string, required: true): Array<Attachment>;
+    getFileUploadValues(name: string, required?: boolean): Array<Attachment> | undefined {
+        const component = this.getFileUploadComponent(name, required as false);
+        return component?.values && mapRawToResolved("attachment", component.values, this.resolved.attachments, false);
     }
 
     /**


### PR DESCRIPTION
https://discord.com/developers/docs/change-log#introducing-the-file-upload-component-in-modals
https://discord.com/developers/docs/components/reference#file-upload

Is just passing attachments like this on createMessage supposed to work, or do you have to download and reupload it? The logged attachment is what's the value. (Just asking to ensure it's not something wrong with this PR)

<img width="2069" height="755" alt="image" src="https://github.com/user-attachments/assets/63c372cd-b3eb-4535-8759-088bfd474e3e" />
