### PR TITLE
Fix Guild#createBan not using deleteMessageSeconds provided via options

### DIFF
--- a/lib/routes/Guilds.ts
+++ b/lib/routes/Guilds.ts
@@ -248,7 +248,7 @@ export default class Guilds {
      */
     async createBan(guildID: string, userID: string, options?: CreateBanOptions): Promise<void> {
         options = this._manager.client.util._freeze(options);
-        let deleteMessageSeconds: number | undefined;
+        let deleteMessageSeconds: number | undefined = options?.deleteMessageSeconds;
         if (options?.deleteMessageDays !== undefined && !Object.hasOwn(options, "deleteMessageSeconds")) {
             deleteMessageSeconds = options.deleteMessageDays! * 86400;
         }


### PR DESCRIPTION
When `deleteMessageSeconds` is provided directly via the options, without being transformed via `deleteMessageDays`, it is not passed in the request body. This bug causes messages not to be deleted by the ban.

Code to replicate the issue:
```js
client.rest.guilds.createBan("guildID", "userID", {
    deleteMessageSeconds: 3600,
});
```