### PR TITLE
Allow ModalFileUploadComponent in ModalLabel

### DIFF
--- a/lib/types/channels.d.ts
+++ b/lib/types/channels.d.ts
@@ -1499,14 +1499,14 @@ export interface RawContainerComponent extends Omit<BaseComponent, "id"> {
 }
 
 export interface ModalLabel extends BaseComponent {
-    component: SelectMenuComponent | TextInput;
+    component: ModalLabelComponent;
     description?: string;
     label: string;
     type: ComponentTypes.LABEL;
 }
 
 export interface RawModalLabel extends Omit<BaseComponent, "id"> {
-    component: RawSelectMenuComponent | RawTextInput;
+    component: RawModalLabelComponent;
     description?: string;
     label: string;
     type: ComponentTypes.LABEL;


### PR DESCRIPTION
Since this is the only place where you can use the component (AFAIK)... it didn't seem possible to actually use `ModalFileUploadComponent` in typescript without tricks? lol
The definitions of `ModalLabelComponent` and `RawModalLabelComponent` do actually include `ModalFileUploadComponent` thankfully