### PR TITLE
Expose more UnfurledMediaItem fields

### DIFF
--- a/lib/types/channels.d.ts
+++ b/lib/types/channels.d.ts
@@ -1206,7 +1206,6 @@ export interface MessagePollResults {
 }
 
 export interface RawTextDisplayComponent extends Omit<TextDisplayComponent, "id"> {}
-export interface RawThumbnailComponent extends Omit<ThumbnailComponent, "id"> {}
 export interface RawSeparatorComponent extends Omit<SeparatorComponent, "id"> {}
 
 export interface RawSectionComponent extends BaseComponent {
@@ -1468,6 +1467,13 @@ export interface TextDisplayComponent extends BaseComponent {
 export interface ThumbnailComponent extends BaseComponent {
     description?: string;
     media: UnfurledMediaItem;
+    spoiler?: boolean;
+    type: ComponentTypes.THUMBNAIL;
+}
+
+export interface RawThumbnailComponent extends Omit<BaseComponent, "id"> {
+    description?: string;
+    media: RawUnfurledMediaItem;
     spoiler?: boolean;
     type: ComponentTypes.THUMBNAIL;
 }

--- a/lib/types/channels.d.ts
+++ b/lib/types/channels.d.ts
@@ -1207,9 +1207,7 @@ export interface MessagePollResults {
 
 export interface RawTextDisplayComponent extends Omit<TextDisplayComponent, "id"> {}
 export interface RawThumbnailComponent extends Omit<ThumbnailComponent, "id"> {}
-export interface RawMediaGalleryComponent extends Omit<MediaGalleryComponent, "id"> {}
 export interface RawSeparatorComponent extends Omit<SeparatorComponent, "id"> {}
-export interface RawFileComponent extends Omit<FileComponent, "id"> {}
 
 export interface RawSectionComponent extends BaseComponent {
     accessory: RawThumbnailComponent | RawButtonComponent;
@@ -1438,8 +1436,22 @@ export interface TextInput extends BaseComponent {
     value?: string;
 }
 
-export interface UnfurledMediaItem {
+export interface RawUnfurledMediaItem {
+    attachment_id?: string;
+    content_type?: string;
+    height?: number;
+    proxy_url?: string;
     url: string;
+    width?: number;
+}
+
+export interface UnfurledMediaItem {
+    attachmentID?: string;
+    contentType?: string;
+    height?: number;
+    proxyURL?: string;
+    url: string;
+    width?: number;
 }
 
 export interface SectionComponent extends BaseComponent {
@@ -1460,6 +1472,12 @@ export interface ThumbnailComponent extends BaseComponent {
     type: ComponentTypes.THUMBNAIL;
 }
 
+export interface RawMediaGalleryItem {
+    description?: string;
+    media: RawUnfurledMediaItem;
+    spoiler?: boolean;
+}
+
 export interface MediaGalleryItem {
     description?: string;
     media: UnfurledMediaItem;
@@ -1468,6 +1486,11 @@ export interface MediaGalleryItem {
 
 export interface MediaGalleryComponent extends BaseComponent {
     items: Array<MediaGalleryItem>;
+    type: ComponentTypes.MEDIA_GALLERY;
+}
+
+export interface RawMediaGalleryComponent extends Omit<BaseComponent, "id"> {
+    items: Array<RawMediaGalleryItem>;
     type: ComponentTypes.MEDIA_GALLERY;
 }
 
@@ -1480,6 +1503,13 @@ export interface SeparatorComponent extends BaseComponent {
 export interface FileComponent extends BaseComponent {
     // The UnfurledMediaItem ONLY supports attachment://<filename> references
     file: UnfurledMediaItem;
+    spoiler?: boolean;
+    type: ComponentTypes.FILE;
+}
+
+export interface RawFileComponent extends Omit<BaseComponent, "id"> {
+    // The RawUnfurledMediaItem ONLY supports attachment://<filename> references
+    file: RawUnfurledMediaItem;
     spoiler?: boolean;
     type: ComponentTypes.FILE;
 }

--- a/lib/util/Util.ts
+++ b/lib/util/Util.ts
@@ -237,9 +237,24 @@ export default class Util {
                 }
             }
 
-            case ComponentTypes.TEXT_DISPLAY:
-            case ComponentTypes.THUMBNAIL: {
+            case ComponentTypes.TEXT_DISPLAY: {
                 return component as never;
+            }
+
+            case ComponentTypes.THUMBNAIL: {
+                return {
+                    description: component.description,
+                    media:       {
+                        attachmentID: component.media.attachment_id,
+                        contentType:  component.media.content_type,
+                        height:       component.media.height,
+                        proxyURL:     component.media.proxy_url,
+                        url:          component.media.url,
+                        width:        component.media.width
+                    },
+                    spoiler: component.spoiler,
+                    type:    component.type
+                } as never;
             }
 
             case ComponentTypes.MEDIA_GALLERY: {
@@ -390,9 +405,24 @@ export default class Util {
                 }
             }
 
-            case ComponentTypes.TEXT_DISPLAY:
-            case ComponentTypes.THUMBNAIL: {
+            case ComponentTypes.TEXT_DISPLAY: {
                 return component as never;
+            }
+
+            case ComponentTypes.THUMBNAIL: {
+                return {
+                    description: component.description,
+                    media:       {
+                        attachment_id: component.media.attachmentID,
+                        content_type:  component.media.contentType,
+                        height:        component.media.height,
+                        proxy_url:     component.media.proxyURL,
+                        url:           component.media.url,
+                        width:         component.media.width
+                    },
+                    spoiler: component.spoiler,
+                    type:    component.type
+                } as never;
             }
 
             case ComponentTypes.MEDIA_GALLERY: {

--- a/lib/util/Util.ts
+++ b/lib/util/Util.ts
@@ -238,9 +238,43 @@ export default class Util {
             }
 
             case ComponentTypes.TEXT_DISPLAY:
-            case ComponentTypes.THUMBNAIL:
-            case ComponentTypes.MEDIA_GALLERY:
-            case ComponentTypes.FILE:
+            case ComponentTypes.THUMBNAIL: {
+                return component as never;
+            }
+
+            case ComponentTypes.MEDIA_GALLERY: {
+                return {
+                    items: component.items.map(i => ({
+                        description: i.description,
+                        media:       {
+                            attachmentID: i.media.attachment_id,
+                            contentType:  i.media.content_type,
+                            height:       i.media.height,
+                            proxyURL:     i.media.proxy_url,
+                            url:          i.media.url,
+                            width:        i.media.width
+                        },
+                        spoiler: i.spoiler
+                    })),
+                    type: component.type
+                } as never;
+            }
+
+            case ComponentTypes.FILE: {
+                return {
+                    file: {
+                        attachmentID: component.file.attachment_id,
+                        contentType:  component.file.content_type,
+                        height:       component.file.height,
+                        proxyURL:     component.file.proxy_url,
+                        url:          component.file.url,
+                        width:        component.file.width
+                    },
+                    spoiler: component.spoiler,
+                    type:    component.type
+                } as never;
+            }
+
             case ComponentTypes.SEPARATOR: {
                 return component as never;
             }
@@ -357,9 +391,43 @@ export default class Util {
             }
 
             case ComponentTypes.TEXT_DISPLAY:
-            case ComponentTypes.THUMBNAIL:
-            case ComponentTypes.MEDIA_GALLERY:
-            case ComponentTypes.FILE:
+            case ComponentTypes.THUMBNAIL: {
+                return component as never;
+            }
+
+            case ComponentTypes.MEDIA_GALLERY: {
+                return {
+                    items: component.items.map(i => ({
+                        description: i.description,
+                        media:       {
+                            attachment_id: i.media.attachmentID,
+                            content_type:  i.media.contentType,
+                            height:        i.media.height,
+                            proxy_url:     i.media.proxyURL,
+                            url:           i.media.url,
+                            width:         i.media.width
+                        },
+                        spoiler: i.spoiler
+                    })),
+                    type: component.type
+                } as never;
+            }
+
+            case ComponentTypes.FILE: {
+                return {
+                    file: {
+                        attachment_id: component.file.attachmentID,
+                        content_type:  component.file.contentType,
+                        height:        component.file.height,
+                        proxy_url:     component.file.proxyURL,
+                        url:           component.file.url,
+                        width:         component.file.width
+                    },
+                    spoiler: component.spoiler,
+                    type:    component.type
+                } as never;
+            }
+
             case ComponentTypes.SEPARATOR: {
                 return component as never;
             }


### PR DESCRIPTION
When an UnfurledMediaItem is received from Discord as part of an existing component, it contains various fields that are currently unexposed by Oceanic. This should expose those missing fields.

https://discord.com/developers/docs/components/reference#unfurled-media-item