### PR TITLE
Allow editing `avatar`, `banner` and `bio` in `EditCurrentMemberOptions`

### DIFF
--- a/lib/routes/Guilds.ts
+++ b/lib/routes/Guilds.ts
@@ -706,10 +706,31 @@ export default class Guilds {
      * @caches {@link Guild#members | Guild#members}<br>{@link Guild#clientMember | Guild#clientMember}
      */
     async editCurrentMember(guildID: string, options: EditCurrentMemberOptions): Promise<Member> {
+        options = this._manager.client.util._freeze(options);
+
+        let avatar = options.avatar;
+        let banner = options.banner;
+        let bio = options.bio;
+
+        if (avatar) {
+            avatar = this._manager.client.util._convertImage(avatar, "avatar");
+        }
+
+        if (banner) {
+            banner = this._manager.client.util._convertImage(banner, "banner");
+        }
+
+        /**
+         * @TODO https://github.com/discord/discord-api-docs/issues/8067
+         */
+        if (bio === null) {
+            bio = "";
+        }
+
         return this._manager.authRequest<RESTMember>({
             method: "PATCH",
             path:   Routes.GUILD_MEMBER(guildID, "@me"),
-            json:   { nick: options.nick },
+            json:   { nick: options.nick, banner, avatar, bio },
             reason: options.reason
         }).then(data => this._manager.client.util.updateMember(guildID, data.user.id, data));
     }

--- a/lib/routes/Guilds.ts
+++ b/lib/routes/Guilds.ts
@@ -710,7 +710,6 @@ export default class Guilds {
 
         let avatar = options.avatar;
         let banner = options.banner;
-        let bio = options.bio;
 
         if (avatar) {
             avatar = this._manager.client.util._convertImage(avatar, "avatar");
@@ -720,17 +719,10 @@ export default class Guilds {
             banner = this._manager.client.util._convertImage(banner, "banner");
         }
 
-        /**
-         * @TODO https://github.com/discord/discord-api-docs/issues/8067
-         */
-        if (bio === null) {
-            bio = "";
-        }
-
         return this._manager.authRequest<RESTMember>({
             method: "PATCH",
             path:   Routes.GUILD_MEMBER(guildID, "@me"),
-            json:   { nick: options.nick, banner, avatar, bio },
+            json:   { nick: options.nick, banner, avatar, bio: options.bio },
             reason: options.reason
         }).then(data => this._manager.client.util.updateMember(guildID, data.user.id, data));
     }

--- a/lib/routes/Users.ts
+++ b/lib/routes/Users.ts
@@ -25,13 +25,16 @@ export default class Users {
      */
     async editSelf(options: EditSelfUserOptions): Promise<ExtendedUser> {
         options = this._manager.client.util._freeze(options);
-        let avatar: string | undefined, banner: string | undefined;
-        if (options.avatar) {
-            avatar = this._manager.client.util._convertImage(options.avatar, "avatar");
+
+        let avatar = options.avatar;
+        let banner = options.banner;
+
+        if (avatar) {
+            avatar = this._manager.client.util._convertImage(avatar, "avatar");
         }
 
-        if (options.banner) {
-            banner = this._manager.client.util._convertImage(options.banner, "banner");
+        if (banner) {
+            banner = this._manager.client.util._convertImage(banner, "banner");
         }
 
         return this._manager.authRequest<RawOAuthUser>({

--- a/lib/types/guilds.d.ts
+++ b/lib/types/guilds.d.ts
@@ -483,7 +483,14 @@ export interface EditMemberOptions {
     roles?: Array<string>;
 }
 
-export interface EditCurrentMemberOptions extends Pick<EditMemberOptions, "nick" | "reason"> {}
+export interface EditCurrentMemberOptions extends Pick<EditMemberOptions, "nick" | "reason"> {
+    /** The new avatar (buffer, or full data url). `null` to reset. */
+    avatar?: Buffer | string | null;
+    /** The new banner (buffer, or full data url). `null` to reset. */
+    banner?:  Buffer | string | null;
+    /** The new bio. `null` to reset. */
+    bio?: string | null;
+}
 
 export interface EditOnboardingOptions {
     /** Channel IDs that members get opted into automatically. */


### PR DESCRIPTION
### New Features
- Add `avatar`, `banner`, and `bio` options to `EditCurrentMemberOptions`.

### Bug Fixes
- Fix `editSelf` not correctly resetting the user's `avatar` and `banner`.

### References:
- https://discord.com/developers/docs/resources/guild#modify-current-member

> [!NOTE]
> https://github.com/discord/discord-api-docs/issues/8067 (Patched)