### PR TITLE
feat: Add file type filtering

### DIFF
--- a/lib/Constants.ts
+++ b/lib/Constants.ts
@@ -45,6 +45,8 @@ export const ImageFormats = [
 ] as const;
 export type ImageFormat = typeof ImageFormats[number];
 
+export type FilterFileTypes = "image" | "video" | "audio" | `.${string}`;
+
 export enum WebhookTypes {
     INCOMING         = 1,
     CHANNEL_FOLLOWER = 2,

--- a/lib/types/applications.d.ts
+++ b/lib/types/applications.d.ts
@@ -36,7 +36,8 @@ import type {
     TeamPayoutAccountStatus,
     TeamPayoutGateway,
     TeamMemberRoleType,
-    ApplicationType
+    ApplicationType,
+    FilterFileTypes
 } from "../Constants";
 import type ApplicationCommand from "../structures/ApplicationCommand";
 import type ClientApplication from "../structures/ClientApplication";
@@ -271,6 +272,7 @@ export interface RawApplicationCommandOption {
     description: string;
     description_localizations?: LocaleMap | null;
     description_localized?: string;
+    file_types?: Array<FilterFileTypes>;
     max_length?: number;
     max_value?: number;
     min_length?: number;
@@ -289,6 +291,7 @@ export interface CombinedApplicationCommandOption {
     choices?: Array<ApplicationCommandOptionsChoice<ApplicationCommandOptionsTypesWithChoices>>;
     description: string;
     descriptionLocalizations?: LocaleMap | null;
+    fileTypes?: Array<FilterFileTypes>;
     maxLength?: number;
     maxValue?: number;
     minLength?: number;
@@ -378,7 +381,11 @@ interface ApplicationCommandOptionsSubCommandGroup extends ApplicationCommandOpt
     options?: Array<ApplicationCommandOptionsSubCommand | ApplicationCommandOptionsWithValue>;
 }
 
-export interface ApplicationCommandOptionsAttachment extends ApplicationCommandOptionBase<ApplicationCommandOptionTypes.ATTACHMENT> {}
+interface ApplicationCommandOptionsFileTypeFilter {
+    fileTypes?: Array<FilterFileTypes>;
+}
+
+export interface ApplicationCommandOptionsAttachment extends ApplicationCommandOptionBase<ApplicationCommandOptionTypes.ATTACHMENT>, ApplicationCommandOptionsFileTypeFilter {}
 export interface ApplicationCommandOptionsBoolean extends ApplicationCommandOptionBase<ApplicationCommandOptionTypes.BOOLEAN> {}
 export interface ApplicationCommandOptionsChannel extends ApplicationCommandOptionBase<ApplicationCommandOptionTypes.CHANNEL>, ApplicationCommandOptionsChannelTypes {}
 export type ApplicationCommandOptionsInteger = ApplicationCommandOptionBase<ApplicationCommandOptionTypes.INTEGER> & Types.Shared.ExclusifyUnion<ApplicationCommandOptionsAutocomplete | ApplicationCommandOptionsMinMaxValue | ApplicationCommandOptionsChoices<ApplicationCommandOptionTypes.INTEGER>>;

--- a/lib/types/channels.d.ts
+++ b/lib/types/channels.d.ts
@@ -36,7 +36,8 @@ import type {
     SeparatorSpacingSize,
     GuildInviteChannelTypes,
     DMInviteChannelTypes,
-    MessageReferenceType
+    MessageReferenceType,
+    FilterFileTypes
 } from "../Constants";
 import type Member from "../structures/Member";
 import type AnnouncementChannel from "../structures/AnnouncementChannel";
@@ -1545,6 +1546,7 @@ export interface RawModalLabel extends Omit<BaseComponent, "id"> {
 
 export interface ModalFileUploadComponent extends BaseComponent {
     customID: string;
+    fileTypes?: Array<FilterFileTypes>;
     maxValues?: number;
     minValues?: number;
     required?: boolean;
@@ -1553,6 +1555,7 @@ export interface ModalFileUploadComponent extends BaseComponent {
 
 export interface RawModalFileUploadComponent extends BaseComponent {
     custom_id: string;
+    file_types?: Array<FilterFileTypes>;
     max_values?: number;
     min_values?: number;
     required?: boolean;

--- a/lib/util/Util.ts
+++ b/lib/util/Util.ts
@@ -288,6 +288,7 @@ export default class Util {
             case ComponentTypes.FILE_UPLOAD: {
                 return {
                     customID:  component.custom_id,
+                    fileTypes: component.file_types,
                     maxValues: component.max_values,
                     minValues: component.min_values,
                     required:  component.required,
@@ -491,6 +492,7 @@ export default class Util {
             case ComponentTypes.FILE_UPLOAD:
                 return {
                     custom_id:  component.customID,
+                    file_types: component.fileTypes,
                     max_values: component.maxValues,
                     min_values: component.minValues,
                     required:   component.required,
@@ -830,6 +832,7 @@ export default class Util {
             description:              option.description,
             descriptionLocalizations: option.description_localizations,
             descriptionLocalized:     option.description_localized,
+            fileTypes:                option.file_types,
             max_length:               option.max_length,
             max_value:                option.max_value,
             min_length:               option.min_length,
@@ -855,6 +858,7 @@ export default class Util {
             })),
             description:               opt.description,
             description_localizations: opt.descriptionLocalizations,
+            file_types:                opt.fileTypes,
             max_length:                opt.maxLength,
             max_value:                 opt.maxValue,
             min_length:                opt.minLength,


### PR DESCRIPTION
Another upcoming feature rollout (ETA: 3 weeks). Adds support for specifying accepted filetypes on file upload components and slash command attachment options.